### PR TITLE
[Bug]: remove trim for empty lines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,14 @@
 
 ## Issue link
 
+<!--
 If your PR closes an issue, use the `closes` keyword followed
 by its link, for example: 
 
 > closes https://github.com/nank1ro/codigo-questions/issues/{ISSUE_NUMBER}
 
 replacing `{ISSUE_NUMBER}` with the number, like: `1`
+-->
 
 ## Type of Change
 

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -1,3 +1,7 @@
-## 1.0.0
+## 0.0.3
+
+- Bug: remove trim for empty lines
+
+## 0.0.1
 
 - Initial version.

--- a/parser/lib/src/blocs/md_parser_bloc.dart
+++ b/parser/lib/src/blocs/md_parser_bloc.dart
@@ -199,13 +199,11 @@ Exercise file path: $filePath
       }
       if (!_skip && !containsCodeOperator) {
         final encodedValue = _parseToUtf8(val);
-        if (encodedValue.trim().isNotEmpty) {
-          result.update(
-            index,
-            (prev) => '$prev\n$encodedValue',
-            ifAbsent: () => encodedValue,
-          );
-        }
+        result.update(
+          index,
+          (prev) => '$prev\n$encodedValue',
+          ifAbsent: () => encodedValue,
+        );
       } else if (_skip) {
         index++;
       }

--- a/parser/pubspec.yaml
+++ b/parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parser
 description: The codigo questions parser.
-version: 0.0.2
+version: 0.0.3
 publish_to: none
 
 environment:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- Remove the trim for empty lines, because the app cannot validate the exercise if the solution has not the same line length.
- Updated the `PULL_REQUEST_TEMPLATE`

## Issue link

> closes https://github.com/nank1ro/codigo-questions/issues/4

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
