### PR TITLE
[Bugfix] fixed a bug in the content parser that truncated spaces as well as new lines

### DIFF
--- a/en/python/dictionaries/3.md
+++ b/en/python/dictionaries/3.md
@@ -31,8 +31,8 @@ print(user["profession"])
 - ]
 - "profession"
 - "Developer"
-- [3]
 -  = 
+- [3]
 
 # --solutions--
 

--- a/it/python/dictionaries/3.md
+++ b/it/python/dictionaries/3.md
@@ -31,8 +31,8 @@ print(utente["professione"])
 - ]
 - "professione"
 - "Sviluppatore"
-- [3]
 -  = 
+- [3]
 
 # --solutions--
 

--- a/parser/lib/src/blocs/md_parser_bloc.dart
+++ b/parser/lib/src/blocs/md_parser_bloc.dart
@@ -141,7 +141,7 @@ class MDParserBLoC {
       startIndex + tag.length,
       endIndex != -1 ? endIndex : fullContent.length,
     );
-    return content.trim();
+    return content.trimNewLines();
   }
 
   /// Returns the list of asserts (if any) from the provided [fileContent].
@@ -342,5 +342,25 @@ Exercise file path: $filePath
       solutions = _getAllItemsInList(solutionsContent);
     }
     return solutions;
+  }
+}
+
+extension on String {
+  /// Creates a new string with the last occurrence of [from] replaced by [to].
+  String replaceLast(Pattern from, String to) {
+    final match = from.allMatches(this).last;
+    return replaceRange(match.start, match.end, to);
+  }
+
+  /// Trims out all the new lines (`\n` specifically) in both the leading and the trailing sides.
+  String trimNewLines() {
+    var initialString = this;
+    while (initialString.startsWith('\n')) {
+      initialString = initialString.replaceFirst('\n', '');
+    }
+    while (initialString.endsWith('\n')) {
+      initialString = initialString.replaceLast('\n', '');
+    }
+    return initialString;
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description


Given a content like this:

```
- something-with-trailing-spaces      



```

the parsed content was

```
- something-with-trailing-spaces
```

instead of 
```
- something-with-trailing-spaces      
```

The difference is that in the first case also the trailing spaces were removed, and this is bad because the solutions must match completely (including the spaces).

In addition, to make the exercise working immediately without waiting for a new app release, the last solution that included the trailing space has been moved before.

## Issue link

> closes https://github.com/nank1ro/codigo-questions/issues/19

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
