### PR TITLE
Fix split sort-items solutions in dart exercises

### DIFF
--- a/de/dart/assignmentOperators/16.md
+++ b/de/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/de/dart/assignmentOperators/17.md
+++ b/de/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/de/dart/forLoops/17.md
+++ b/de/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/de/dart/forLoops/18.md
+++ b/de/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/en/dart/assignmentOperators/16.md
+++ b/en/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/en/dart/assignmentOperators/17.md
+++ b/en/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/en/dart/forLoops/17.md
+++ b/en/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/en/dart/forLoops/18.md
+++ b/en/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/es/dart/assignmentOperators/16.md
+++ b/es/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/es/dart/assignmentOperators/17.md
+++ b/es/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/es/dart/forLoops/17.md
+++ b/es/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/es/dart/forLoops/18.md
+++ b/es/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/fr/dart/assignmentOperators/16.md
+++ b/fr/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/fr/dart/assignmentOperators/17.md
+++ b/fr/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/fr/dart/forLoops/17.md
+++ b/fr/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/fr/dart/forLoops/18.md
+++ b/fr/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/hi/dart/assignmentOperators/16.md
+++ b/hi/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/hi/dart/assignmentOperators/17.md
+++ b/hi/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/hi/dart/forLoops/17.md
+++ b/hi/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/hi/dart/forLoops/18.md
+++ b/hi/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/it/dart/assignmentOperators/16.md
+++ b/it/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/it/dart/assignmentOperators/17.md
+++ b/it/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/it/dart/forLoops/17.md
+++ b/it/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/it/dart/forLoops/18.md
+++ b/it/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/ja/dart/assignmentOperators/16.md
+++ b/ja/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/ja/dart/assignmentOperators/17.md
+++ b/ja/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/ja/dart/forLoops/17.md
+++ b/ja/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/ja/dart/forLoops/18.md
+++ b/ja/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/ko/dart/assignmentOperators/16.md
+++ b/ko/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/ko/dart/assignmentOperators/17.md
+++ b/ko/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/ko/dart/forLoops/17.md
+++ b/ko/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/ko/dart/forLoops/18.md
+++ b/ko/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/pl/dart/assignmentOperators/16.md
+++ b/pl/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/pl/dart/assignmentOperators/17.md
+++ b/pl/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/pl/dart/forLoops/17.md
+++ b/pl/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/pl/dart/forLoops/18.md
+++ b/pl/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/pt/dart/assignmentOperators/16.md
+++ b/pt/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/pt/dart/assignmentOperators/17.md
+++ b/pt/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/pt/dart/forLoops/17.md
+++ b/pt/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/pt/dart/forLoops/18.md
+++ b/pt/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/ru/dart/assignmentOperators/16.md
+++ b/ru/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/ru/dart/assignmentOperators/17.md
+++ b/ru/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/ru/dart/forLoops/17.md
+++ b/ru/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/ru/dart/forLoops/18.md
+++ b/ru/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```

--- a/zh/dart/assignmentOperators/16.md
+++ b/zh/dart/assignmentOperators/16.md
@@ -33,21 +33,9 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int counter = 5;
-```
-
-```dart
   counter += 10;
-```
-
-```dart
   print(counter);
-```
-
-```dart
 }
 ```
 

--- a/zh/dart/assignmentOperators/17.md
+++ b/zh/dart/assignmentOperators/17.md
@@ -41,29 +41,11 @@ void main() {
 
 ```dart
 void main() {
-```
-
-```dart
   int score = 10;
-```
-
-```dart
   score += 6;
-```
-
-```dart
   score *= 2;
-```
-
-```dart
   score -= 14;
-```
-
-```dart
   print(score);
-```
-
-```dart
 }
 ```
 

--- a/zh/dart/forLoops/17.md
+++ b/zh/dart/forLoops/17.md
@@ -22,12 +22,6 @@ for (int i = 0; i < 3; i++) {
 # --solutions--
 ```dart
 for (int i = 0; i < 3; i++) {
-```
-
-```dart
   print(i);
-```
-
-```dart
 }
 ```

--- a/zh/dart/forLoops/18.md
+++ b/zh/dart/forLoops/18.md
@@ -26,16 +26,7 @@ for (var n in nums) {
 # --solutions--
 ```dart
 List<int> nums = [1, 2, 3];
-```
-
-```dart
 for (var n in nums) {
-```
-
-```dart
   print(n);
-```
-
-```dart
 }
 ```


### PR DESCRIPTION
Four type-4 (sort items) Dart exercises had their `--solutions--` section split into one fenced block per row. The app compares the user's rows joined by newlines against each solutions block, so these could never be solved.

Fixed (all 12 locales): `dart/assignmentOperators/16.md`, `dart/assignmentOperators/17.md`, `dart/forLoops/17.md`, `dart/forLoops/18.md` — the blocks are now a single fenced block containing the whole program.

Checked and left alone (legitimate alternative orderings): `dart/booleans/14.md`, `dart/comments/5.md`, `*/output/5.md`, `kotlin/output/6.md`.

Validator passes; solution programs re-run locally and match `--output--`; locale code sections identical to en.