### PR TITLE
Add pipeline tooling: new-argument workflow, merge/check scripts, docs

### DIFF
--- a/.claude/workflows/new-argument.js
+++ b/.claude/workflows/new-argument.js
@@ -1,0 +1,189 @@
+export const meta = {
+  name: 'new-argument',
+  description: 'Author a new exercise argument (or challenge set) for one language, review it, translate to 11 locales, verify with validator+tester, open a PR',
+  whenToUse: 'Pass args: [{language, argument, title, description, count, assetFrom?, notes?}, ...]. One item per topic; items run in parallel, each in its own worktree /tmp/codigo-new/<language>-<argument>. Requires codecompiler on localhost:8080 and tester/.env in the main checkout.',
+  phases: [
+    { title: 'Write', detail: 'author en exercises + data.json in a fresh worktree' },
+    { title: 'Review', detail: 'independent content review (ambiguity, pedagogy, facts)' },
+    { title: 'Fix', detail: 'apply confirmed findings' },
+    { title: 'Translate', detail: '3 locale groups, Sonnet' },
+    { title: 'Verify', detail: 'validator, tester, output/locale checks, regenerate' },
+    { title: 'Ship', detail: 'commit, push, open PR' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Inputs. `args` is an array of topic specs (or one spec). All fields except
+// notes/assetFrom are required.
+//   language   c | dart | javascript | kotlin | python | swift
+//   argument   folder name, must match assets/arguments/<argument>.svg (or set assetFrom
+//              to an existing asset name to copy, e.g. assetFrom: 'dictionaries')
+//   title      display title for data.json (e.g. "Maps")
+//   description one-line description for data.json
+//   count      number of exercises to write (12-25)
+//   notes      optional extra guidance for the author (scope, must-cover concepts)
+// ---------------------------------------------------------------------------
+const SPECS = (Array.isArray(args) ? args : [args]).filter(Boolean)
+if (!SPECS.length) throw new Error('new-argument: pass args as an array of {language, argument, title, description, count}')
+
+const MAIN = '/Users/ale/.t3/worktrees/codigo-questions/t3code-3441c85c'
+const LOCALE_GROUPS = [['de', 'es', 'fr', 'it'], ['pt', 'pl', 'ru', 'zh'], ['ja', 'ko', 'hi']]
+
+const FORMAT_RULES = `
+Exercise format: read CLAUDE.md in the worktree root. Key rules:
+- Sections: '# --description--', '# --instructions--', '# --seed--', '# --answers--', '# --before-seed--', '# --after-seed--', '# --before-asserts--', '# --asserts--', '# --after-asserts--', '# --solutions--', '# --output--'.
+- Type 1 (run code): use the language harness EXACTLY as in existing type-1 exercises of the same language (copy the '# --before-seed--' / '# --after-asserts--' blocks from a neighbour; see validator/lib/constants.dart). Dart type-1 uses --before-asserts--/--asserts--/--after-asserts-- with package:test and wraps user code that must expose values in a result() function (see en/dart/assignmentOperators/10.md). Kotlin type-1 puts user code inside fun main() via the before-seed; anything that must be top-level (classes with companion objects, objects) needs the harness main moved to '# --before-asserts--' (see en/kotlin/classes/7.md). Swift uses the tryCatch helper, never XCTest.
+- Type 2 (fill spaces): '[/]' placeholders in the seed; '# --answers--' is a '- token' list with distractors; the instructions plus the stated '# --output--' must make exactly ONE token per slot valid (a distractor that also compiles and prints the same output is a defect).
+- Type 3 (choose answer): '- text' answers; the '# --solutions--' entry must match one answer EXACTLY; only one answer may be defensible.
+- Type 4 (sort items): one fenced block per row in '# --answers--'; '# --solutions--' holds ONE fenced block with the whole program (rows joined by newlines); extra fenced blocks in the same section are alternative valid orderings. If several top-level orderings are valid, either list them all or constrain the instructions ("define the function before main").
+- '# --output--' for type 2/4 must be exactly what the solution prints.
+- Every concept an exercise uses must be introduced in a '# --description--' of that exercise or an earlier one in the same folder (descriptions are concatenated into _theory.md, which only includes the leading run of consecutive exercises that have descriptions, so give the first ~5 exercises descriptions and any later exercise that introduces something new).
+- Mix: roughly 45% type 1, 25% type 2, 15% type 3, 15% type 4; progress from basic to advanced; short, concrete instructions; code must compile under the current toolchain (Dart 3 null safety, Kotlin 2, Swift 5, C11, Python 3, Node 22).`
+
+const CHECKS = (s) => `
+Checks (run from the worktree root; codecompiler must be running on localhost:8080):
+  cp ${MAIN}/tester/.env tester/.env
+  for d in validator tester json_creator theory_creator; do (cd $d && dart pub get >/dev/null); done
+  (cd validator && dart test lib/validator.dart --reporter=failures-only --chain-stack-traces --fail-fast 2>&1 | tail -20)
+  (cd tester && dart run bin/tester.dart -p 'en/${s.language}/${s.argument}/*.md' -t 1 2>&1 | tail -40)
+  python3 scripts/check_outputs.py 'en/${s.language}/${s.argument}/*.md'
+  python3 scripts/check_locales.py WORKTREE`
+
+const WRITE_SCHEMA = {
+  type: 'object',
+  properties: {
+    worktree: { type: 'string' },
+    files: { type: 'array', items: { type: 'string' } },
+    typeMix: { type: 'string' },
+    notes: { type: 'string' },
+  },
+  required: ['worktree', 'files', 'typeMix', 'notes'],
+}
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, defect: { type: 'string' }, fix: { type: 'string' } }, required: ['file', 'defect', 'fix'] } },
+  },
+  required: ['findings'],
+}
+const REPORT_SCHEMA = {
+  type: 'object',
+  properties: {
+    validator: { type: 'string', enum: ['pass', 'fail'] },
+    tester: { type: 'string' },
+    outputs: { type: 'string' },
+    locales: { type: 'string' },
+    fixesApplied: { type: 'array', items: { type: 'string' } },
+    remainingProblems: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['validator', 'tester', 'outputs', 'locales', 'fixesApplied', 'remainingProblems'],
+}
+const SHIP_SCHEMA = {
+  type: 'object',
+  properties: { branch: { type: 'string' }, commit: { type: 'string' }, prUrl: { type: 'string' }, notes: { type: 'string' } },
+  required: ['branch', 'commit', 'prUrl', 'notes'],
+}
+
+const wt = (s) => `/tmp/codigo-new/${s.language}-${s.argument}`
+const branch = (s) => `feat/${s.language}-${s.argument}`
+
+function writePrompt(s) {
+  return `You are a senior ${s.language} educator writing a new exercise argument for the Codigo app.
+
+SETUP (exactly):
+  cd ${MAIN} && git fetch -q origin && mkdir -p /tmp/codigo-new && git worktree add ${wt(s)} -b ${branch(s)} origin/main
+  cd ${wt(s)}
+Work ONLY inside ${wt(s)}. Do NOT commit, push, stash, checkout or touch other worktrees.
+
+TOPIC: language=${s.language}, argument folder=en/${s.language}/${s.argument}/, title="${s.title}", description="${s.description}", exercises to write: ${s.count}.
+${s.notes ? 'Author notes: ' + s.notes : ''}
+
+Before writing, study: translations/en/templates/${s.language}_{1,2,3,4}.md; three existing arguments of this language (e.g. the most recent folders in en/${s.language}/) for tone, harness and difficulty curve; the same topic in another language if it exists (e.g. en/python/${s.argument}, en/swift/${s.argument}); and en/${s.language}/data.json for the order values.
+${FORMAT_RULES}
+
+Deliverables:
+1. en/${s.language}/${s.argument}/1.md ... ${s.count}.md
+2. en/${s.language}/data.json: add "${s.argument}": {"order": <max existing order + 1>, "title": "${s.title}", "description": "${s.description}"}
+3. assets/arguments/${s.argument}.svg must exist. ${s.assetFrom ? `It does not: copy assets/arguments/${s.assetFrom}.svg to assets/arguments/${s.argument}.svg.` : 'It should already exist; if not, stop and say so in notes.'}
+Do NOT create _theory.md (generated later).
+${CHECKS(s)}
+Iterate until validator passes, every type-1 exercise PASSes in the tester, check_outputs reports 0 failed, and check_locales reports only MISSING lines for the 11 other locales (they are translated later). Return worktree, the list of files, the type mix, and notes.`
+}
+
+function reviewPrompt(s) {
+  return `You are an independent reviewer of new coding exercises. Read-only: do not modify files, do not run git commands that change state. Files: ${wt(s)}/en/${s.language}/${s.argument}/*.md (numbered, read in order) plus ${wt(s)}/CLAUDE.md for the format.
+
+Report ONLY actual defects, each with file path, the defect, and a one-line fix:
+- Factually wrong statements about ${s.language}.
+- Type 3: more than one defensible answer, or the solution text does not exactly match an answer.
+- Type 2: a distractor token would also make the code valid AND match the stated --output--; or the instructions do not determine the answer uniquely.
+- Type 4: more than one valid ordering while only one is listed and the instructions do not constrain order.
+- --output-- that does not match what the solution prints.
+- Instructions inconsistent with seed/solution (names, values); asserts that pass without doing what the instructions ask (e.g. inheritance never checked).
+- A concept used before any earlier/same exercise description introduces it.
+- Harness mistakes: Dart type-1 not using result()/expect pattern where values are checked; Kotlin top-level-only constructs inside main; Swift XCTest; missing --err-tN-- markers.
+Compile/run correctness of type-1 solutions was already verified by execution; skip that. No style nits. Return the findings list (empty if none).`
+}
+
+function fixPrompt(s, findings) {
+  return `Fix worker for the new exercises in ${wt(s)} (cd there; do NOT commit/push/checkout/stash). Scope: ONLY the findings below, in en/${s.language}/${s.argument}/ (and en/${s.language}/data.json if named). For each finding first confirm it is real by reading the file; skip it (and say why) if it is not. Apply minimal fixes that keep the exercise's intent.
+${FORMAT_RULES}
+Findings:
+${findings.map((f, i) => `${i + 1}. ${f.file}: ${f.defect}\n   fix: ${f.fix}`).join('\n')}
+${CHECKS(s)}
+All must pass again (validator, tester for type 1, check_outputs). Return a short list of what you changed and what you skipped.`
+}
+
+function translatePrompt(s, group) {
+  return `You are a translator for the Codigo exercise repo. Work ONLY inside ${wt(s)} (cd there). No git commands that change state. Write only under these locale folders: ${group.join(', ')}.
+${FORMAT_RULES}
+Source of truth: en/${s.language}/${s.argument}/*.md (numbered files only, ignore _theory.md) and the "${s.argument}" entry in en/${s.language}/data.json.
+
+For EACH locale in ${group.join(', ')}:
+- Create <locale>/${s.language}/${s.argument}/<n>.md for every en file, a faithful translation. Frontmatter, seed, type-2 answers, before-seed/after-seed, before-asserts, assert CODE blocks, after-asserts, solutions and output must be BYTE-IDENTICAL to en (code comments stay in English). Translate description, instructions, the prose line above each assert code block, type-3 answers and type-3 solutions (the translated solution must equal one translated answer exactly). Keep markdown structure, section order, code spans, '[/]' placeholders, '--err-tN--' markers and blank-line layout identical to en. Translate complete sentences; no English words left behind.
+- Add the "${s.argument}" entry to <locale>/${s.language}/data.json with the same order and a translated title/description (match the style of the neighbouring entries in that file; keep the JSON formatting of the file).
+- Match the tone and terminology used by existing translations in <locale>/${s.language}/.
+
+Verify: python3 scripts/check_locales.py WORKTREE must print no DIFF/MISSING line for your locales; also 'ls <locale>/${s.language}/${s.argument}/*.md | wc -l' must equal en's count for each of your locales. Return locales handled, file counts, and anything unresolved.`
+}
+
+function verifyPrompt(s) {
+  return `Verifier for ${wt(s)} (cd there; no commit/push/checkout/stash; you MAY edit files to fix problems).
+${CHECKS(s)}
+Also: for each locale in de es fr hi it ja ko pl pt ru zh, the file count in <locale>/${s.language}/${s.argument}/ must equal en's, and <locale>/${s.language}/data.json must contain "${s.argument}". Then regenerate: (cd json_creator && dart run lib/json_creator.dart) and (cd theory_creator && dart run lib/theory_creator.dart), and run the validator once more. Finally 'git status --short' must list only: en + 11 locale folders for ${s.language}/${s.argument}, the 12 data.json files, curriculum.json, _theory.md files, and assets/arguments/${s.argument}.svg if new; tester/.env is ignored.
+If something fails and the fix is mechanical or clearly correct (a locale code section differing from en -> copy en's; a missing translated file -> translate it; a missing data.json entry -> add it; an untranslated English sentence in a locale -> translate it), fix it and re-run. Anything needing a content decision goes to remainingProblems with the exact error text.
+${FORMAT_RULES}`
+}
+
+function shipPrompt(s, report) {
+  return `Ship the branch in ${wt(s)} (cd there). Verification report: ${JSON.stringify(report)}.
+${report.remainingProblems.length ? 'There are remaining problems; still open the PR but list them in the PR body under "Known issues".' : ''}
+Steps:
+  git add -A -- '*.md' '*/data.json' curriculum.json assets   # never stage stray helper scripts
+  /Users/ale/.local/bin/agent-commit -m "Feat/${s.language} ${s.argument}: add ${s.count} exercises across 12 locales"
+    (agent-commit is mandatory; if it reports that the commit-review gate needs a review, do NOT bypass: stop and return notes="gate blocked" with the exact message.)
+  git push -u origin ${branch(s)}
+  gh pr create --base main --head ${branch(s)} --title "Feat/${s.language} ${s.argument}" --body "<summary: exercise count and type mix, concepts covered in order, checks run (validator, tester, check_outputs, check_locales), and any known issues>"
+Return branch, commit sha, PR URL, notes.`
+}
+
+const results = await pipeline(
+  SPECS,
+  (s) => agent(writePrompt(s), { label: `write:${s.language}-${s.argument}`, phase: 'Write', schema: WRITE_SCHEMA }),
+  (w, s) => {
+    if (!w) throw new Error('write failed')
+    return agent(reviewPrompt(s), { label: `review:${s.language}-${s.argument}`, phase: 'Review', model: 'opus', schema: FINDINGS_SCHEMA })
+      .then((r) => ({ w, findings: (r && r.findings) || [] }))
+  },
+  ({ w, findings }, s) => {
+    if (!findings.length) { log(`${s.language}/${s.argument}: review clean`); return w }
+    log(`${s.language}/${s.argument}: ${findings.length} review findings`)
+    return agent(fixPrompt(s, findings), { label: `fix:${s.language}-${s.argument}`, phase: 'Fix' }).then(() => w)
+  },
+  (w, s) => parallel(LOCALE_GROUPS.map((g) => () => agent(translatePrompt(s, g), { label: `translate:${s.language}-${s.argument}:${g[0]}`, phase: 'Translate', model: 'sonnet' }))).then(() => w),
+  (w, s) => agent(verifyPrompt(s), { label: `verify:${s.language}-${s.argument}`, phase: 'Verify', model: 'opus', schema: REPORT_SCHEMA }),
+  (report, s) => agent(shipPrompt(s, report), { label: `ship:${s.language}-${s.argument}`, phase: 'Ship', model: 'sonnet', schema: SHIP_SCHEMA })
+    .then((ship) => ({ language: s.language, argument: s.argument, worktree: wt(s), report, ship })),
+)
+
+return results

--- a/DAILY_PIPELINE.md
+++ b/DAILY_PIPELINE.md
@@ -1,5 +1,39 @@
 # Daily Exercise Generation Pipeline
 
+## TL;DR (current tooling, Sept 2026)
+
+The pipeline below is implemented as a saved Claude Code workflow: `.claude/workflows/new-argument.js`.
+Run it from a Claude Code session in this repo (opt in with "use a workflow" / "ultracode"):
+
+```
+Workflow name: new-argument
+args: [{ "language": "kotlin", "argument": "maps", "title": "Maps",
+         "description": "Learn how to store key-value pairs in a Map", "count": 18,
+         "assetFrom": "dictionaries", "notes": "concepts to cover, in order" }, ...]
+```
+
+Per topic it runs: Write (author en/ in `/tmp/codigo-new/<language>-<argument>`, own branch) →
+Review (independent content review) → Fix → Translate (3 Sonnet agents, 11 locales) → Verify
+(validator, tester, `scripts/check_outputs.py`, `scripts/check_locales.py`, regenerate) → Ship
+(agent-commit, push, `gh pr create`). Several topics run in parallel.
+
+Prerequisites: codecompiler running (`cd /Users/ale/github/codecompiler && HTTP_SERVER_PORT=8080 go run ./cmd/httpserver`)
+and `tester/.env` in the main checkout (see `tester/README.md`).
+
+To merge a resulting PR: `scripts/merge_pr.sh <worktree-name> <pr-number>` (set `WORKTREE=` when the
+worktree is not under `/tmp/codigo-fix/`). It rebases onto main, merges per-locale `data.json`
+entries from both sides, regenerates `curriculum.json`/`_theory.md`, pushes, waits for CI and
+squash-merges. Merge PRs one at a time (they all touch `curriculum.json`).
+
+Local checks that CI does not run:
+- `scripts/check_outputs.py 'en/<lang>/<arg>/*.md'` runs type 2/4 solutions locally and compares stdout with `--output--`.
+- `scripts/check_locales.py WORKTREE` (or a git ref) verifies every locale's code sections are byte-identical to en.
+- `tester/` executes type-1 solutions through codecompiler.
+
+Assets: no new icons are available; new arguments must reuse `assets/arguments/*.svg` (use `assetFrom`
+to copy an existing icon under the new argument name).
+
+
 ## Context
 
 Automated daily pipeline that generates new exercises for a language+argument, validates them, translates to all 12 locales, and opens a PR. Designed to be re-run daily. Can process multiple arguments/challenges in parallel.

--- a/scripts/check_locales.py
+++ b/scripts/check_locales.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Compare code-bearing sections between en and other locales, for files a branch adds/changes under en/."""
+import re, sys, os, subprocess
+def sections(md):
+    out = {}
+    t = re.search(r'exerciseType:\s*(\d)', md); t = int(t.group(1)) if t else 0
+    for m in re.finditer(r'^# --([a-z-]+)--\s*\n(.*?)(?=^# --|\Z)', md, re.S | re.M):
+        name, body = m.group(1), m.group(2)
+        if name in ('description', 'instructions'): continue
+        if t == 3 and name in ('answers', 'solutions'): continue
+        if name == 'asserts':
+            body = '\n'.join(re.findall(r'```[a-z]*\n(.*?)```', body, re.S))
+        out[name] = '\n'.join(l.rstrip() for l in body.splitlines()).strip('\n')
+    fm = re.search(r'^---\n(.*?)\n---', md, re.S)
+    out['frontmatter'] = re.sub(r'title:.*', '', fm.group(1)).strip() if fm else ''
+    return out
+branch = sys.argv[1]  # a git ref, or WORKTREE to compare files on disk against origin/main
+if branch == 'WORKTREE':
+    files = subprocess.run(['git', 'diff', '--name-only', 'origin/main', '--', 'en/'], capture_output=True, text=True, check=True).stdout.split()
+    files += subprocess.run(['git', 'ls-files', '--others', '--exclude-standard', 'en/'], capture_output=True, text=True, check=True).stdout.split()
+else:
+    files = subprocess.run(['git', 'diff', '--name-only', f'origin/main...{branch}', '--', 'en/'], capture_output=True, text=True, check=True).stdout.split()
+locales = sorted(d for d in os.listdir('.') if len(d) == 2 and d != 'en' and os.path.isdir(d))
+bad = 0
+def show(path):
+    if branch == 'WORKTREE':
+        return open(path).read() if os.path.exists(path) else ''
+    return subprocess.run(['git', 'show', f'{branch}:{path}'], capture_output=True, text=True).stdout
+for enf in files:
+    if not enf.endswith('.md') or os.path.basename(enf).startswith('_'): continue
+    en = sections(show(enf)); rel = enf.split('/', 1)[1]
+    for loc in locales:
+        lf = f'{loc}/{rel}'; md = show(lf)
+        if not md: print(f'MISSING {lf}'); bad += 1; continue
+        l = sections(md)
+        for k in sorted(set(en) | set(l)):
+            if en.get(k) != l.get(k):
+                bad += 1; print(f'DIFF {lf} [{k}]\n  en: {en.get(k, "")[:120]}\n  {loc}: {l.get(k, "")[:120]}')
+print(f'{bad} problems in {len(files)} en files x {len(locales)} locales')

--- a/scripts/check_outputs.py
+++ b/scripts/check_outputs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Run type 2/4 (and type 1 with --output--) solutions locally and compare stdout to --output--."""
+import re, sys, subprocess, tempfile, os, glob
+
+def section(md, name):
+    m = re.search(r'^# --%s--\s*\n(.*?)(?=^# --|\Z)' % name, md, re.S | re.M)
+    return m.group(1) if m else None
+
+def blocks(txt):
+    return re.findall(r'```[a-z]*\n(.*?)```', txt, re.S)
+
+def run(lang, code):
+    d = tempfile.mkdtemp()
+    if lang == 'dart':
+        if not re.search(r'\bmain\s*\(', code): code = 'void main() {\n' + code + '\n}\n'
+        f = os.path.join(d, 'main.dart'); open(f, 'w').write(code)
+        cmd = ['dart', 'run', f]
+    elif lang == 'kotlin':
+        if not re.search(r'\bfun\s+main\s*\(', code): code = 'fun main() {\n' + code + '\n}\n'
+        f = os.path.join(d, 'main.kt'); open(f, 'w').write(code)
+        r = subprocess.run(['kotlinc', f, '-include-runtime', '-d', d + '/o.jar'], capture_output=True, text=True, timeout=180)
+        if r.returncode: return r.stdout + r.stderr, r.returncode
+        cmd = ['java', '-jar', d + '/o.jar']
+    elif lang == 'swift':
+        f = os.path.join(d, 'main.swift'); open(f, 'w').write(code)
+        cmd = ['swift', f]
+    elif lang == 'c':
+        if not re.search(r'\bmain\s*\(', code): code = '#include <stdio.h>\n#include <string.h>\n#include <stdbool.h>\nint main() {\n' + code + '\nreturn 0;\n}\n'
+        f = os.path.join(d, 'main.c'); open(f, 'w').write(code)
+        r = subprocess.run(['gcc', f, '-o', d + '/a.out', '-lm'], capture_output=True, text=True)
+        if r.returncode: return r.stdout + r.stderr, r.returncode
+        cmd = [d + '/a.out']
+    elif lang == 'python':
+        f = os.path.join(d, 'main.py'); open(f, 'w').write(code); cmd = ['python3', f]
+    elif lang == 'javascript':
+        f = os.path.join(d, 'main.js'); open(f, 'w').write(code); cmd = ['node', f]
+    else:
+        return 'unsupported', 1
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    return r.stdout + ('' if r.returncode == 0 else r.stderr), r.returncode
+
+fails = 0; ran = 0
+for pattern in sys.argv[1:]:
+    for path in sorted(glob.glob(pattern, recursive=True)):
+        if os.path.basename(path).startswith('_'): continue
+        md = open(path).read()
+        t = re.search(r'exerciseType:\s*(\d)', md); lang = re.search(r'language:\s*(\w+)', md)
+        if not t or not lang: continue
+        t = int(t.group(1)); lang = lang.group(1)
+        out = section(md, 'output'); sol = section(md, 'solutions')
+        if t == 3 or out is None or sol is None: continue
+        if t == 1: continue  # tester covers these
+        bl = blocks(sol)
+        # type 2 and 4: each block is a full program (extra blocks are alternative orderings)
+        ran += 1
+        for i, code in enumerate(bl or ['']):
+            got, rc = run(lang, code)
+            if rc != 0 or got.strip() != out.strip():
+                fails += 1
+                print(f'FAIL {path} (t{t}, block {i+1}, rc={rc})\n  expected: {out.strip()!r}\n  got:      {got.strip()[:400]!r}')
+                break
+        else:
+            print(f'ok   {path}')
+print(f'\n{ran} run, {fails} failed')
+sys.exit(1 if fails else 0)

--- a/scripts/merge_datajson.py
+++ b/scripts/merge_datajson.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Resolve a rebase conflict in a data.json: start from ours (upstream/main), add entries only present in theirs (branch), bump colliding 'order'."""
+import json, subprocess, sys
+from collections import OrderedDict
+for path in sys.argv[1:]:
+    ours = json.loads(subprocess.check_output(['git', 'show', f':2:{path}']), object_pairs_hook=OrderedDict)
+    theirs = json.loads(subprocess.check_output(['git', 'show', f':3:{path}']), object_pairs_hook=OrderedDict)
+    orders = {v.get('order') for v in ours.values() if isinstance(v, dict) and 'order' in v}
+    for k, v in theirs.items():
+        if k in ours: continue
+        if isinstance(v, dict) and 'order' in v and v['order'] in orders:
+            v['order'] = max(orders) + 1
+        if isinstance(v, dict) and 'order' in v: orders.add(v['order'])
+        ours[k] = v
+    with open(path, 'w') as f:
+        json.dump(ours, f, indent=2, ensure_ascii=False); f.write('\n')
+    subprocess.check_call(['git', 'add', path])
+    print('merged', path)

--- a/scripts/merge_pr.sh
+++ b/scripts/merge_pr.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# usage: scripts/merge_pr.sh <worktree-name> <pr-number>   (WORKTREE=/path overrides /tmp/codigo-fix/<name>)
+# Rebases the PR worktree onto origin/main (merging per-locale data.json entries, regenerating curriculum/theory),
+# pushes, waits for CI, then squash-merges with admin override.
+n=$1; pr=$2; SCRIPTS=$(cd "$(dirname "$0")" && pwd)
+cd "${WORKTREE:-/tmp/codigo-fix/$n}" || exit 1
+git fetch -q origin
+b=$(git branch --show-current)
+git rebase origin/main >/tmp/rb-$n.log 2>&1 || { [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ] || { echo "$n: REBASE FAILED"; tail -5 /tmp/rb-$n.log; exit 2; }; }
+while [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; do
+  conflicts=$(git diff --name-only --diff-filter=U)
+  if [ -z "$conflicts" ]; then echo "$n: rebase stuck without conflicts"; git rebase --abort; exit 2; fi
+  echo "$n: resolving: $(echo $conflicts | tr '\n' ' ')"
+  for f in ${=conflicts}; do case $f in curriculum.json|*/_theory.md) git checkout --ours -- $f; git add $f;; */data.json) python3 "$SCRIPTS/merge_datajson.py" $f >/dev/null;; *) echo "$n: UNEXPECTED CONFLICT $f"; git rebase --abort; exit 2;; esac; done
+  GIT_EDITOR=true git rebase --continue >>/tmp/rb-$n.log 2>&1
+done
+(cd json_creator && dart run lib/json_creator.dart >/dev/null 2>&1) && (cd theory_creator && dart run lib/theory_creator.dart >/dev/null 2>&1) || { echo "$n: GENERATOR FAILED"; exit 2; }
+git add -A
+if ! git diff --cached --quiet; then
+  echo "Rebase of $b onto main after other PRs merged: per-locale data.json entries merged from both sides (unique order values), curriculum.json and _theory.md regenerated with json_creator/theory_creator. No exercise content changes intended." > /tmp/req-regen.md
+  /Users/ale/.local/bin/agent-commit -m "Merge data.json entries after rebase; rebuild curriculum and theory" >/dev/null 2>&1
+  if ! git diff --cached --quiet; then
+    out=$(/Users/ale/.local/bin/agent-review start --author fable --requirements /tmp/req-regen.md 2>&1)
+    dir=$(echo "$out" | grep -oE "/Users/[^ ]+agent-reviews/[^ ]+" | head -1)
+    if echo "$out" | grep -q ": 0 findings"; then
+      /Users/ale/.local/bin/agent-review finish "$dir" >/dev/null 2>&1
+      /Users/ale/.local/bin/agent-commit -m "Merge data.json entries after rebase; rebuild curriculum and theory" 2>&1 | tail -1
+    else
+      echo "$n: regen review FINDINGS -> $dir"; echo "$out" | tail -3; exit 3
+    fi
+  fi
+  git diff --cached --quiet || { echo "$n: regen commit still blocked"; exit 3; }
+fi
+(cd validator && dart test lib/validator.dart --reporter=failures-only --chain-stack-traces --fail-fast >/tmp/val-$n.log 2>&1) || { echo "$n: VALIDATOR FAILED"; tail -20 /tmp/val-$n.log; exit 4; }; tail -1 /tmp/val-$n.log
+git push --force-with-lease=$b:$(git rev-parse origin/$b) origin $b 2>&1 | tail -1
+git fetch -q origin; [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/$b)" ] || { echo "$n: PUSH FAILED"; exit 5; }
+for i in 1 2 3 4 5 6; do [ "$(gh pr checks $pr --json name --jq length 2>/dev/null)" -gt 0 ] 2>/dev/null && break; sleep 20; done
+[ "$(gh pr checks $pr --json name --jq length 2>/dev/null)" -gt 0 ] 2>/dev/null || { echo "$n: NO CI CHECKS FOUND"; exit 4; }
+gh pr checks $pr --watch --interval 20 --fail-fast >/tmp/ci-$n.log 2>&1 || { echo "$n: CI FAILED"; tail -10 /tmp/ci-$n.log; exit 4; }
+tail -5 /tmp/ci-$n.log
+gh pr merge $pr --squash --admin --delete-branch >/tmp/merge-$n.log 2>&1 || { echo "$n: MERGE FAILED"; cat /tmp/merge-$n.log; exit 6; }
+echo "$n: MERGED"


### PR DESCRIPTION
Local tooling for the content pipeline (no exercise changes):

- `.claude/workflows/new-argument.js`: Workflow script that authors a new argument for one language, reviews/fixes it, translates to 11 locales (Sonnet), verifies (validator, tester, output and locale checks) and opens a PR.
- `scripts/check_outputs.py`: runs type 2/4 solutions locally and compares to `--output--`.
- `scripts/check_locales.py`: checks code sections match between en and the other locales for files a branch changes.
- `scripts/merge_datajson.py` + `scripts/merge_pr.sh`: rebase a PR worktree on main resolving generated-file and data.json conflicts, regenerate, validate, wait for CI, squash-merge.
- `DAILY_PIPELINE.md`: TL;DR of the current process.

Used to ship #206–#211.