### PR TITLE
Fix CI concurrency group on push events

### DIFF
--- a/.github/workflows/build_validate.yml
+++ b/.github/workflows/build_validate.yml
@@ -17,7 +17,7 @@ jobs:
   validate_exercises:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     defaults:
       run:
@@ -52,7 +52,7 @@ jobs:
     needs: validate_exercises
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     defaults:
       run:
@@ -87,7 +87,7 @@ jobs:
     needs: build_curriculum
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref || github.ref }}
       cancel-in-progress: true
     defaults:
       run:


### PR DESCRIPTION
Push-to-main runs of Validate and build failed with `Unexpected value ''` because `github.head_ref` is empty outside pull_request events. Fall back to `github.ref` in all three jobs. Astra review: 0 findings.