### PR TITLE
Retry GLM translation once before reporting missing files

### DIFF
--- a/.claude/workflows/new-argument.js
+++ b/.claude/workflows/new-argument.js
@@ -137,7 +137,7 @@ All must pass again (validator, tester for type 1, check_outputs). Return a shor
 function translatePrompt(s, group) {
   return `Translation is done by GLM through OpenCode; you only drive the script. From ${wt(s)} run, one after another (each takes several minutes; wait for it):
 ${group.map((l) => `sh ${MAIN}/scripts/translate_glm.sh ${s.language} ${s.argument} ${l}`).join('\n')}
-Each run ends by printing either "ok <locale> (<n> files)" or DIFF/MISSING lines for that locale. If a locale prints DIFF/MISSING lines, run its command once more. Do not edit any file yourself. Return one line per locale with its final printed result.`
+Each run ends by printing either "ok <locale> (<n> files)" or, after its own retry, the remaining DIFF/MISSING lines for that locale. Do not edit any file yourself. Return one line per locale with its final printed result.`
 }
 
 function verifyPrompt(s) {

--- a/scripts/translate_glm.sh
+++ b/scripts/translate_glm.sh
@@ -8,6 +8,10 @@ Source of truth: en/$L/$A/*.md (numbered files only, ignore _theory.md) and the 
 For every en/$L/$A/<n>.md create $LOC/$L/$A/<n>.md, a faithful translation into the language of locale '$LOC'. Frontmatter, seed, type-2 '# --answers--' tokens, before-seed, after-seed, before-asserts, assert code blocks, after-asserts, solutions and output must be BYTE-IDENTICAL to en (code comments stay in English). Translate: description, instructions, the prose line above each assert code block, type-3 answers and type-3 solutions (the translated solution must equal one translated answer exactly). Keep markdown structure, section order, code spans, '[/]' placeholders, '--err-tN--' markers and blank-line layout identical to en. Translate complete sentences; leave no English prose behind. Match the tone and terminology of existing files in $LOC/$L/.
 Add the \"$A\" entry to $LOC/$L/data.json with the same order as en and a translated title/description, matching the style and JSON formatting of the neighbouring entries.
 When done run: python3 scripts/check_locales.py WORKTREE and fix every DIFF or MISSING line for locale $LOC until none remain. Reply with one line: DONE or the remaining problems."
-opencode run --dir "$(pwd)" -m zai-coding-plan/glm-5.3-flash --format json "$PROMPT" > "/tmp/glm-$L-$A-$LOC.log" 2>&1 || true
-OUT=$(python3 scripts/check_locales.py WORKTREE) || { echo "check_locales.py failed for $LOC"; exit 1; }
-printf '%s\n' "$OUT" | grep -E "^(DIFF|MISSING) $LOC/" || echo "ok $LOC ($(ls $LOC/$L/$A/*.md 2>/dev/null | wc -l | tr -d ' ') files)"
+for attempt in 1 2; do
+  opencode run --dir "$(pwd)" -m zai-coding-plan/glm-5.3-flash --format json "$PROMPT" > "/tmp/glm-$L-$A-$LOC.log" 2>&1 || true
+  OUT=$(python3 scripts/check_locales.py WORKTREE) || { echo "check_locales.py failed for $LOC"; exit 1; }
+  BAD=$(printf '%s\n' "$OUT" | grep -E "^(DIFF|MISSING) $LOC/") || { echo "ok $LOC ($(ls $LOC/$L/$A/*.md 2>/dev/null | wc -l | tr -d ' ') files)"; exit 0; }
+done
+printf '%s\n' "$BAD"
+exit 1


### PR DESCRIPTION
translate_glm.sh now re-runs GLM once when check_locales still reports DIFF/MISSING for the locale, so the Opus verifier no longer has to translate leftover files itself (happened for 2 of 66 locale runs in batch 5). The haiku driver prompt drops its manual retry. Reviewed through the agent-review gate (Sol: 0 findings).