### PR TITLE
Feat/javascript nullability

### DIFF
--- a/curriculum.json
+++ b/curriculum.json
@@ -261,6 +261,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -296,7 +301,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -874,6 +879,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -909,7 +919,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -1487,6 +1497,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -1522,7 +1537,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -2100,6 +2115,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -2135,7 +2155,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -2713,6 +2733,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -2748,7 +2773,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -3326,6 +3351,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -3361,7 +3391,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -3939,6 +3969,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -3974,7 +4009,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -4552,6 +4587,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -4587,7 +4627,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -5165,6 +5205,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -5200,7 +5245,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -5778,6 +5823,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -5813,7 +5863,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -6391,6 +6441,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -6426,7 +6481,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",
@@ -7004,6 +7059,11 @@
           "totalExercises": 16
         },
         {
+          "name": "nullability",
+          "trainUntil": 14,
+          "totalExercises": 16
+        },
+        {
           "name": "objects",
           "trainUntil": 7,
           "totalExercises": 7
@@ -7039,7 +7099,7 @@
           "totalExercises": 44
         }
       ],
-      "totalExercises": 351
+      "totalExercises": 367
     },
     {
       "name": "kotlin",

--- a/de/javascript/data.json
+++ b/de/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Pfeilfunktionen",
         "description": "Lerne, wie man kurze anonyme Funktionen schreibt"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullability",
+        "description": "Lerne, wie man mit Werten umgeht, die null oder undefined sein können"
     }
 }

--- a/de/javascript/nullability/1.md
+++ b/de/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript hat zwei verschiedene Möglichkeiten, um „hier ist kein Wert" auszudrücken.
+`undefined` bedeutet, dass ein Wert **nie angegeben** wurde. Eine Variable, die ohne Wert deklariert wird, enthält `undefined`, und ebenso eine Eigenschaft, die in einem Objekt nicht existiert:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` ist ein Wert, den **du** absichtlich zuweist, um zu sagen: „leer, und ich weiß es":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+`undefined` ist also meistens die Sprache, die dir sagt, dass etwas fehlt, während `null` der Programmierer ist, der erklärt, dass etwas absichtlich leer ist.
+
+# --instructions--
+
+Vervollständige den Code, sodass `city` ohne Wert deklariert wird und `owner` explizit auf `null` gesetzt ist
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/de/javascript/nullability/10.md
+++ b/de/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Ein **Standardparameter** gibt einem Parameter einen Wert, wenn der Aufrufer keinen liefert. Die Regel ist präzise: Der Standardwert wird nur verwendet, wenn das Argument `undefined` ist, was auch das Weglassen einschließt. `null` zu übergeben löst den Standardwert **nicht** aus, weil `null` ein Wert ist:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Standardparameter folgen der `undefined`-Regel, während `??` sowohl `null` als auch `undefined` abdeckt: Wähle das, das dazu passt, wie deine Funktion aufgerufen wird.
+
+# --instructions--
+
+Schreibe eine Funktion `pad(text, width = 5)`, die `text` gefolgt von so vielen `"."`-Zeichen zurückgibt, wie nötig sind, um `width` Zeichen zu erreichen, mit einem Standardparameter für `width`; wenn `text` bereits `width` Zeichen oder länger ist, gib es unverändert zurück
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` muss `"ab.."` zurückgeben.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` muss `"ab..."` zurückgeben, mit der Standardbreite von `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` muss ebenfalls die Standardbreite verwenden.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` muss `"ab"` zurückgeben, weil `null` den Standardwert nicht auslöst und zu `0` umgewandelt wird.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` muss `"abcdef"` unverändert zurückgeben.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` muss als Standardparameter deklariert sein.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/de/javascript/nullability/11.md
+++ b/de/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Optionale Verkettung und die `== null`-Prüfung arbeiten gut zusammen: Die Kette liest den verschachtelten Wert, ohne einen Fehler zu werfen, und die Prüfung entscheidet, was zu tun ist, wenn das Ergebnis fehlt:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Im letzten `return` ist ein einfacher `.` sicher, weil die Prüfung bereits bewiesen hat, dass jedes Glied existiert.
+
+# --instructions--
+
+Sortiere die Zeilen, um `cityOf` zu definieren, das `"unknown"` zurückgibt, wenn der Benutzer keine Stadt hat, und sonst die Stadt, und gib danach das Ergebnis für einen Benutzer ohne Adresse und für einen Benutzer aus, der in `Rome` wohnt. Definiere zuerst die Funktion
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/de/javascript/nullability/12.md
+++ b/de/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Viele eingebaute Methoden melden „nichts gefunden", indem sie `undefined` zurückgeben. Die Array-Methode `find(callback)` ist das typische Beispiel: Sie gibt das erste Element zurück, für das der Callback `true` ist, oder `undefined`, wenn kein Element passt:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Hier `found.price` zu lesen würde einen Fehler werfen, also sind `?.` und `??` die natürlichen Begleiter von `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Schreibe eine Funktion `priceOf(products, name)`, die den `price` des Produkts aus `products` zurückgibt, dessen `name` übereinstimmt, oder `null`, wenn es kein solches Produkt gibt, und verwende dabei `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` muss `7` zurückgeben.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` muss `null` zurückgeben.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` muss `null` zurückgeben.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` muss `0` zurückgeben, nicht `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+Die Funktion muss `find` verwenden.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/de/javascript/nullability/13.md
+++ b/de/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` und `undefined` verhalten sich unterschiedlich, wenn ein Objekt mit `JSON.stringify()` in JSON umgewandelt wird.
+JSON hat einen `null`-Wert, aber kein `undefined`, daher wird eine Eigenschaft, deren Wert `undefined` ist, einfach **weggelassen**, während eine `null`-Eigenschaft erhalten bleibt:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Innerhalb von Arrays können die Positionen nicht verschwinden, daher wird `undefined` dort zu `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+Was gibt dieser Code aus?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/de/javascript/nullability/14.md
+++ b/de/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Die Prüfung `obj.key === undefined` kann zwei Situationen nicht unterscheiden: Die Eigenschaft existiert nicht, oder sie existiert und enthält den Wert `undefined`.
+`Object.hasOwn(obj, key)` beantwortet nur die erste Frage: Es gibt `true` zurück, wenn das Objekt seine **eigene** Eigenschaft namens `key` hat, ganz gleich welchen Werts:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+„Eigene" bedeutet, direkt am Objekt selbst deklariert: Geerbte Member wie `toString` sind an jedem Objekt verfügbar, aber `Object.hasOwn(config, "toString")` ist `false`.
+
+# --instructions--
+
+Schreibe eine Funktion `describeKey(obj, key)`, die `"missing"` zurückgibt, wenn `obj` keine eigene Eigenschaft `key` hat, `"empty"`, wenn die Eigenschaft existiert, aber `null` oder `undefined` enthält, und `"set"` in jedem anderen Fall, und verwende dabei `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` muss `"set"` zurückgeben.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` und `describeKey({ a: "" }, "a")` müssen `"set"` zurückgeben.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` und `describeKey({ a: null }, "a")` müssen `"empty"` zurückgeben.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` muss `"missing"` zurückgeben.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` muss `"missing"` zurückgeben, weil `toString` geerbt ist, nicht eigen.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+Die Funktion muss `Object.hasOwn` verwenden.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/de/javascript/nullability/15.md
+++ b/de/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Sortiere die Zeilen, um `finish` zu definieren, das den optionalen `onDone`-Callback einer Aufgabe aufruft und ihren `name` oder `"untitled"` zurückgibt, und gib danach das Ergebnis für eine Aufgabe namens `build` mit einem Callback aus, der `done` ausgibt, und für eine leere Aufgabe. Definiere zuerst die Funktion
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/de/javascript/nullability/16.md
+++ b/de/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Schreibe eine Funktion `pick(obj, path, fallback)`, wobei `path` eine Zeichenkette aus durch Punkte getrennten Eigenschaftsnamen ist, wie `"address.city"`; sie muss den verschachtelten Wert zurückgeben, der beim Folgen des Pfads gefunden wird, oder `fallback`, wenn ein beliebiger Schritt oder der endgültige Wert `null` oder `undefined` ist; Werte wie `0`, `""` und `false` müssen unverändert zurückgegeben werden
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` muss `"Rome"` zurückgeben.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` muss `"unknown"` zurückgeben.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` muss `0` zurückgeben, ohne einen Fehler zu werfen.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` muss `0` zurückgeben und `pick({ name: "" }, "name", "anon")` muss `""` zurückgeben.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` muss `false` zurückgeben.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` und `pick({ x: undefined }, "x", "none")` müssen `"none"` zurückgeben.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/de/javascript/nullability/2.md
+++ b/de/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Funktionen erzeugen `undefined` in zwei weiteren Situationen.
+Wenn du eine Funktion mit **weniger Argumenten** aufrufst, als sie deklariert, enthalten die fehlenden Parameter `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Wenn eine Funktion **ohne ein `return`** endet (oder mit einem bloßen `return;`), liefert ihr Aufruf `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Beachte, dass das explizite Übergeben von `null` nicht dasselbe ist wie das Weglassen des Arguments: `greet(null)` gibt `null` aus, weil `null` ein echter Wert ist, der an die Funktion übergeben wurde.
+
+# --instructions--
+
+Schreibe eine Funktion `nameOrGuest(name)`, die `"Guest"` zurückgibt, wenn `name` `undefined` ist (zum Beispiel, weil das Argument weggelassen wurde), und in jedem anderen Fall `name` unverändert zurückgibt, einschließlich `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` muss `"Ana"` zurückgeben.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` muss `"Guest"` zurückgeben, weil das fehlende Argument `undefined` ist.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` muss `"Guest"` zurückgeben.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` muss `null` zurückgeben, weil `null` ein Wert ist, der absichtlich übergeben wurde.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` muss `""` zurückgeben.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/de/javascript/nullability/3.md
+++ b/de/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Der Operator `typeof` gibt den Typ eines Werts als String zurück. Für `undefined` antwortet er mit `"undefined"`, wie du es erwartest:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Für `null` antwortet er jedoch mit `"object"`. Das ist ein Bug aus der allerersten Version von JavaScript, der nie behoben wurde, weil zu viel Code davon abhängt:
+```javascript
+console.log(typeof null);
+// prints object
+```
+`typeof` ist also eine zuverlässige Möglichkeit, `undefined` zu erkennen, aber nicht `null`. Um auf `null` zu prüfen, vergleiche direkt damit: `value === null`.
+
+# --instructions--
+
+Was gibt dieser Code aus?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/de/javascript/nullability/4.md
+++ b/de/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Wie verhalten sich `null` und `undefined` beim Vergleich miteinander? Das hängt vom Operator ab.
+Die **lose** Gleichheit `==` behandelt sie als dasselbe und betrachtet sie als verschieden von jedem anderen Wert, einschließlich `0`, `""` und `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+Die **strikte** Gleichheit `===` vergleicht auch den Typ, und `null` und `undefined` haben unterschiedliche Typen:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Vervollständige den Code, sodass die erste Zeile `missing` und `undefined` mit der losen Gleichheit vergleicht, die zweite Zeile mit der strikten Gleichheit, und die dritte Zeile das Ergebnis von `typeof missing` prüft, wodurch die Ausgabe `true`, `false`, `true` entsteht
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/de/javascript/nullability/5.md
+++ b/de/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Meistens ist es dir egal, *welche* der beiden „kein Wert"-Markierungen du erhalten hast: Du willst nur wissen, ob ein Wert vorhanden ist.
+Weil `null == undefined` `true` ist und nichts anderes lose gleich `null` ist, ist der Vergleich `value == null` das Standardidiom, um **beide** auf einmal abzufangen:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Das ist der eine Fall, in dem `==` gegenüber `===` bevorzugt wird: `value === null || value === undefined` zu schreiben erledigt genau dieselbe Aufgabe, nur länger.
+Werte wie `0`, `""` und `false` sind *nicht* `null`: Sie sind echte Werte, die zufällig falsy sind.
+
+# --instructions--
+
+Schreibe eine Funktion `isMissing(value)`, die `true` zurückgibt, wenn `value` `null` oder `undefined` ist, und `false` für jeden anderen Wert
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` muss `true` zurückgeben.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` und `isMissing()` müssen `true` zurückgeben.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` muss `false` zurückgeben.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` und `isMissing(false)` müssen `false` zurückgeben.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` und `isMissing({})` müssen `false` zurückgeben.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/de/javascript/nullability/6.md
+++ b/de/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Das Lesen einer Eigenschaft von `null` oder `undefined` ist ein Fehler, der das Programm stoppt:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` ist `undefined`, und `undefined` hat keine Eigenschaften. Der Operator der **optionalen Verkettung** (optional chaining) `?.` löst das: Wenn der Wert auf seiner linken Seite `null` oder `undefined` ist, bricht der gesamte Ausdruck ab und ergibt `undefined`, statt einen Fehler zu werfen:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Wenn die linke Seite doch einen Wert hat, verhält sich `?.` genau wie ein normaler `.`. Du kannst mehrere verketten: `user.address?.street?.name` gibt `undefined` zurück, sobald ein Glied fehlt.
+
+# --instructions--
+
+Vervollständige den Code, sodass beide Zeilen `undefined` ausgeben, statt einen Fehler zu werfen, und verwende dabei optionale Verkettung
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/de/javascript/nullability/7.md
+++ b/de/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Optionale Verkettung ist nicht auf Punkt-Eigenschaften beschränkt. Es gibt zwei weitere Formen.
+`?.[]` liest ein Element oder einen berechneten Schlüssel nur, wenn die linke Seite einen Wert hat:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` ruft eine Funktion nur auf, wenn sie existiert, was bei optionalen Callbacks praktisch ist:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In jeder Form gilt die Prüfung für den Wert **direkt vor** dem `?.`: `post?.tags?.[0]` ist sicher, selbst wenn `post` selbst `null` oder `undefined` ist.
+
+# --instructions--
+
+Schreibe eine Funktion `firstTag(post)`, die das erste Element von `post.tags` zurückgibt, oder `undefined`, wenn `post` fehlt, kein `tags` hat oder sein `tags`-Array leer ist, und verwende dabei optionale Verkettung statt `if`-Anweisungen
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` muss `"js"` zurückgeben.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` muss `undefined` zurückgeben, weil es keine `tags`-Eigenschaft gibt.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` muss `undefined` zurückgeben.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` und `firstTag(undefined)` müssen `undefined` zurückgeben, ohne einen Fehler zu werfen.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+Die Funktion muss optionale Verkettung verwenden und kein `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/de/javascript/nullability/8.md
+++ b/de/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Sobald du weißt, dass ein Wert fehlen kann, möchtest du meistens einen **Standardwert** an seiner Stelle. Zwei Operatoren tun das, und sie unterscheiden sich darin, was sie als „fehlend" betrachten.
+`a || b` gibt `b` zurück, wann immer `a` **falsy** ist: nicht nur `null` und `undefined`, sondern auch `0`, `""`, `false` und `NaN`.
+Der Operator des **nullish coalescing** `a ?? b` gibt `b` nur zurück, wenn `a` `null` oder `undefined` ist, und behält jeden anderen Wert:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Verwende `??`, wenn `0`, `""` oder `false` legitime Werte sind, die erhalten bleiben müssen, und `||`, wenn du wirklich jeden falsy-Wert ersetzen willst.
+
+# --instructions--
+
+Vervollständige den Code, sodass die erste Zeile die `0` behält, die in `count` gespeichert ist, die zweite Zeile den leeren `name` durch `"Guest"` ersetzt und die dritte Zeile den Wert `false` behält
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/de/javascript/nullability/9.md
+++ b/de/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Ein sehr häufiges Muster ist „setze diese Eigenschaft nur, wenn sie noch nicht gesetzt ist". Mit `??` geschrieben wiederholt es den Namen:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Der Operator der **nullish assignment** `??=` tut dasselbe in einem Schritt: Er weist die rechte Seite nur zu, wenn die linke Seite gerade `null` oder `undefined` ist, und lässt jeden anderen Wert unberührt:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` bleibt `0`, weil `0` nicht nullish ist; `timeout` existierte nicht, also erhält es `1000`. Dieselbe Idee gibt es für `||` als `||=`, das jeden falsy-Wert überschreibt.
+
+# --instructions--
+
+Was gibt dieser Code aus?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/de/javascript/nullability/_theory.md
+++ b/de/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript hat zwei verschiedene Möglichkeiten, um „hier ist kein Wert" auszudrücken.
+`undefined` bedeutet, dass ein Wert **nie angegeben** wurde. Eine Variable, die ohne Wert deklariert wird, enthält `undefined`, und ebenso eine Eigenschaft, die in einem Objekt nicht existiert:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` ist ein Wert, den **du** absichtlich zuweist, um zu sagen: „leer, und ich weiß es":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+`undefined` ist also meistens die Sprache, die dir sagt, dass etwas fehlt, während `null` der Programmierer ist, der erklärt, dass etwas absichtlich leer ist.
+
+---
+
+Funktionen erzeugen `undefined` in zwei weiteren Situationen.
+Wenn du eine Funktion mit **weniger Argumenten** aufrufst, als sie deklariert, enthalten die fehlenden Parameter `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Wenn eine Funktion **ohne ein `return`** endet (oder mit einem bloßen `return;`), liefert ihr Aufruf `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Beachte, dass das explizite Übergeben von `null` nicht dasselbe ist wie das Weglassen des Arguments: `greet(null)` gibt `null` aus, weil `null` ein echter Wert ist, der an die Funktion übergeben wurde.
+
+---
+
+Der Operator `typeof` gibt den Typ eines Werts als String zurück. Für `undefined` antwortet er mit `"undefined"`, wie du es erwartest:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Für `null` antwortet er jedoch mit `"object"`. Das ist ein Bug aus der allerersten Version von JavaScript, der nie behoben wurde, weil zu viel Code davon abhängt:
+```javascript
+console.log(typeof null);
+// prints object
+```
+`typeof` ist also eine zuverlässige Möglichkeit, `undefined` zu erkennen, aber nicht `null`. Um auf `null` zu prüfen, vergleiche direkt damit: `value === null`.
+
+---
+
+Wie verhalten sich `null` und `undefined` beim Vergleich miteinander? Das hängt vom Operator ab.
+Die **lose** Gleichheit `==` behandelt sie als dasselbe und betrachtet sie als verschieden von jedem anderen Wert, einschließlich `0`, `""` und `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+Die **strikte** Gleichheit `===` vergleicht auch den Typ, und `null` und `undefined` haben unterschiedliche Typen:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+Meistens ist es dir egal, *welche* der beiden „kein Wert"-Markierungen du erhalten hast: Du willst nur wissen, ob ein Wert vorhanden ist.
+Weil `null == undefined` `true` ist und nichts anderes lose gleich `null` ist, ist der Vergleich `value == null` das Standardidiom, um **beide** auf einmal abzufangen:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Das ist der eine Fall, in dem `==` gegenüber `===` bevorzugt wird: `value === null || value === undefined` zu schreiben erledigt genau dieselbe Aufgabe, nur länger.
+Werte wie `0`, `""` und `false` sind *nicht* `null`: Sie sind echte Werte, die zufällig falsy sind.
+
+---
+
+Das Lesen einer Eigenschaft von `null` oder `undefined` ist ein Fehler, der das Programm stoppt:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` ist `undefined`, und `undefined` hat keine Eigenschaften. Der Operator der **optionalen Verkettung** (optional chaining) `?.` löst das: Wenn der Wert auf seiner linken Seite `null` oder `undefined` ist, bricht der gesamte Ausdruck ab und ergibt `undefined`, statt einen Fehler zu werfen:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Wenn die linke Seite doch einen Wert hat, verhält sich `?.` genau wie ein normaler `.`. Du kannst mehrere verketten: `user.address?.street?.name` gibt `undefined` zurück, sobald ein Glied fehlt.
+
+---
+
+Optionale Verkettung ist nicht auf Punkt-Eigenschaften beschränkt. Es gibt zwei weitere Formen.
+`?.[]` liest ein Element oder einen berechneten Schlüssel nur, wenn die linke Seite einen Wert hat:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` ruft eine Funktion nur auf, wenn sie existiert, was bei optionalen Callbacks praktisch ist:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In jeder Form gilt die Prüfung für den Wert **direkt vor** dem `?.`: `post?.tags?.[0]` ist sicher, selbst wenn `post` selbst `null` oder `undefined` ist.
+
+---
+
+Sobald du weißt, dass ein Wert fehlen kann, möchtest du meistens einen **Standardwert** an seiner Stelle. Zwei Operatoren tun das, und sie unterscheiden sich darin, was sie als „fehlend" betrachten.
+`a || b` gibt `b` zurück, wann immer `a` **falsy** ist: nicht nur `null` und `undefined`, sondern auch `0`, `""`, `false` und `NaN`.
+Der Operator des **nullish coalescing** `a ?? b` gibt `b` nur zurück, wenn `a` `null` oder `undefined` ist, und behält jeden anderen Wert:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Verwende `??`, wenn `0`, `""` oder `false` legitime Werte sind, die erhalten bleiben müssen, und `||`, wenn du wirklich jeden falsy-Wert ersetzen willst.
+
+---
+
+Ein sehr häufiges Muster ist „setze diese Eigenschaft nur, wenn sie noch nicht gesetzt ist". Mit `??` geschrieben wiederholt es den Namen:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Der Operator der **nullish assignment** `??=` tut dasselbe in einem Schritt: Er weist die rechte Seite nur zu, wenn die linke Seite gerade `null` oder `undefined` ist, und lässt jeden anderen Wert unberührt:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` bleibt `0`, weil `0` nicht nullish ist; `timeout` existierte nicht, also erhält es `1000`. Dieselbe Idee gibt es für `||` als `||=`, das jeden falsy-Wert überschreibt.
+
+---
+
+Ein **Standardparameter** gibt einem Parameter einen Wert, wenn der Aufrufer keinen liefert. Die Regel ist präzise: Der Standardwert wird nur verwendet, wenn das Argument `undefined` ist, was auch das Weglassen einschließt. `null` zu übergeben löst den Standardwert **nicht** aus, weil `null` ein Wert ist:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Standardparameter folgen der `undefined`-Regel, während `??` sowohl `null` als auch `undefined` abdeckt: Wähle das, das dazu passt, wie deine Funktion aufgerufen wird.
+
+---
+
+Optionale Verkettung und die `== null`-Prüfung arbeiten gut zusammen: Die Kette liest den verschachtelten Wert, ohne einen Fehler zu werfen, und die Prüfung entscheidet, was zu tun ist, wenn das Ergebnis fehlt:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Im letzten `return` ist ein einfacher `.` sicher, weil die Prüfung bereits bewiesen hat, dass jedes Glied existiert.
+
+---
+
+Viele eingebaute Methoden melden „nichts gefunden", indem sie `undefined` zurückgeben. Die Array-Methode `find(callback)` ist das typische Beispiel: Sie gibt das erste Element zurück, für das der Callback `true` ist, oder `undefined`, wenn kein Element passt:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Hier `found.price` zu lesen würde einen Fehler werfen, also sind `?.` und `??` die natürlichen Begleiter von `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` und `undefined` verhalten sich unterschiedlich, wenn ein Objekt mit `JSON.stringify()` in JSON umgewandelt wird.
+JSON hat einen `null`-Wert, aber kein `undefined`, daher wird eine Eigenschaft, deren Wert `undefined` ist, einfach **weggelassen**, während eine `null`-Eigenschaft erhalten bleibt:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Innerhalb von Arrays können die Positionen nicht verschwinden, daher wird `undefined` dort zu `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Die Prüfung `obj.key === undefined` kann zwei Situationen nicht unterscheiden: Die Eigenschaft existiert nicht, oder sie existiert und enthält den Wert `undefined`.
+`Object.hasOwn(obj, key)` beantwortet nur die erste Frage: Es gibt `true` zurück, wenn das Objekt seine **eigene** Eigenschaft namens `key` hat, ganz gleich welchen Werts:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+„Eigene" bedeutet, direkt am Objekt selbst deklariert: Geerbte Member wie `toString` sind an jedem Objekt verfügbar, aber `Object.hasOwn(config, "toString")` ist `false`.

--- a/en/javascript/data.json
+++ b/en/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Arrow Functions",
         "description": "Learn how to write short anonymous functions"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullability",
+        "description": "Learn how to handle values that may be null or undefined"
     }
 }

--- a/en/javascript/nullability/1.md
+++ b/en/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript has two different ways to say "there is no value here".
+`undefined` means that a value was **never provided**. A variable declared without a value holds `undefined`, and so does a property that does not exist in an object:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` is a value that **you** assign on purpose to say "empty, and I know it":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+So `undefined` is usually the language telling you that something is missing, while `null` is the programmer stating that something is intentionally empty.
+
+# --instructions--
+
+Complete the code so that `city` is declared without a value and `owner` is explicitly set to `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/en/javascript/nullability/10.md
+++ b/en/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+A **default parameter** gives a parameter a value when the caller does not provide one. The rule is precise: the default is used only when the argument is `undefined`, which includes omitting it. Passing `null` does **not** trigger the default, because `null` is a value:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Default parameters follow the `undefined` rule, while `??` covers both `null` and `undefined`: choose the one that matches how your function will be called.
+
+# --instructions--
+
+Write a function `pad(text, width = 5)` that returns `text` followed by as many `"."` characters as needed to reach `width` characters, using a default parameter for `width`; when `text` is already `width` characters or longer, return it unchanged
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` must return `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` must return `"ab..."`, using the default width of `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` must also use the default width.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` must return `"ab"`, because `null` does not trigger the default and is converted to `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` must return `"abcdef"` unchanged.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` must be declared as a default parameter.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/en/javascript/nullability/11.md
+++ b/en/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Optional chaining and the `== null` guard work well together: the chain reads the nested value without throwing, and the guard decides what to do when the result is missing:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Inside the last `return` a plain `.` is safe, because the guard has already proven that every link exists.
+
+# --instructions--
+
+Sort the lines to define `cityOf`, which returns `"unknown"` when the user has no city and the city otherwise, then print the result for a user without an address and for a user living in `Rome`. Define the function first
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/en/javascript/nullability/12.md
+++ b/en/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Many built-in methods report "nothing found" by returning `undefined`. The array method `find(callback)` is the typical example: it returns the first element for which the callback is `true`, or `undefined` when no element matches:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Reading `found.price` here would throw, so `?.` and `??` are the natural companions of `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Write a function `priceOf(products, name)` that returns the `price` of the product of `products` whose `name` matches, or `null` when there is no such product, using `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` must return `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` must return `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` must return `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` must return `0`, not `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+The function must use `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/en/javascript/nullability/13.md
+++ b/en/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` and `undefined` behave differently when an object is converted to JSON with `JSON.stringify()`.
+JSON has a `null` value but no `undefined`, so a property whose value is `undefined` is simply **left out**, while a `null` property is kept:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Inside arrays the positions cannot disappear, so `undefined` becomes `null` there:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+What does this code print?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/en/javascript/nullability/14.md
+++ b/en/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Checking `obj.key === undefined` cannot tell two situations apart: the property does not exist, or it exists and holds the value `undefined`.
+`Object.hasOwn(obj, key)` answers the first question only: it returns `true` when the object has its **own** property named `key`, whatever its value:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Own" means declared on the object itself: inherited members such as `toString` are available on every object but `Object.hasOwn(config, "toString")` is `false`.
+
+# --instructions--
+
+Write a function `describeKey(obj, key)` that returns `"missing"` when `obj` has no own property `key`, `"empty"` when the property exists but holds `null` or `undefined`, and `"set"` in every other case, using `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` must return `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` and `describeKey({ a: "" }, "a")` must return `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` and `describeKey({ a: null }, "a")` must return `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` must return `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` must return `"missing"`, because `toString` is inherited, not own.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+The function must use `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/en/javascript/nullability/15.md
+++ b/en/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Sort the lines to define `finish`, which calls the optional `onDone` callback of a task and returns its `name` or `"untitled"`, then print the result for a task named `build` with a callback printing `done`, and for an empty task. Define the function first
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/en/javascript/nullability/16.md
+++ b/en/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Write a function `pick(obj, path, fallback)` where `path` is a string of property names separated by dots, such as `"address.city"`; it must return the nested value found by following the path, or `fallback` when any step or the final value is `null` or `undefined`; values such as `0`, `""` and `false` must be returned as they are
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` must return `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` must return `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` must return `0` without throwing.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` must return `0` and `pick({ name: "" }, "name", "anon")` must return `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` must return `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` and `pick({ x: undefined }, "x", "none")` must return `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/en/javascript/nullability/2.md
+++ b/en/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Functions produce `undefined` in two more situations.
+When you call a function with **fewer arguments** than it declares, the missing parameters hold `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+When a function finishes **without a `return`** (or with a bare `return;`), calling it gives `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notice that passing `null` explicitly is not the same as omitting the argument: `greet(null)` prints `null`, because `null` is a real value that was handed to the function.
+
+# --instructions--
+
+Write a function `nameOrGuest(name)` that returns `"Guest"` when `name` is `undefined` (for example because the argument was omitted) and returns `name` unchanged in every other case, including `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` must return `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` must return `"Guest"`, because the missing argument is `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` must return `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` must return `null`, because `null` is a value that was passed on purpose.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` must return `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/en/javascript/nullability/3.md
+++ b/en/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+The `typeof` operator returns the type of a value as a string. For `undefined` it answers `"undefined"`, as you would expect:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+For `null`, however, it answers `"object"`. This is a bug from the very first version of JavaScript that was never fixed, because too much code depends on it:
+```javascript
+console.log(typeof null);
+// prints object
+```
+So `typeof` is a reliable way to detect `undefined`, but not `null`. To check for `null`, compare with it directly: `value === null`.
+
+# --instructions--
+
+What does this code print?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/en/javascript/nullability/4.md
+++ b/en/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+How do `null` and `undefined` compare with each other? It depends on the operator.
+The **loose** equality `==` treats them as the same thing, and considers them different from any other value, including `0`, `""` and `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+The **strict** equality `===` also compares the type, and `null` and `undefined` have different types:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Complete the code so that the first line compares `missing` and `undefined` with the loose equality, the second line with the strict equality, and the third line checks the result of `typeof missing`, producing the output `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/en/javascript/nullability/5.md
+++ b/en/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Most of the time you do not care *which* of the two "no value" markers you got: you just want to know whether a value is there.
+Because `null == undefined` is `true` and nothing else is loosely equal to `null`, the comparison `value == null` is the standard idiom to catch **both** at once:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+This is the one case where `==` is preferred over `===`: writing `value === null || value === undefined` does exactly the same job, only longer.
+Values such as `0`, `""` and `false` are *not* `null`: they are real values that happen to be falsy.
+
+# --instructions--
+
+Write a function `isMissing(value)` that returns `true` when `value` is `null` or `undefined`, and `false` for any other value
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` must return `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` and `isMissing()` must return `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` must return `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` and `isMissing(false)` must return `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` and `isMissing({})` must return `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/en/javascript/nullability/6.md
+++ b/en/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Reading a property of `null` or `undefined` is an error that stops the program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` is `undefined`, and `undefined` has no properties. The **optional chaining** operator `?.` solves this: if the value on its left is `null` or `undefined`, the whole expression stops and evaluates to `undefined` instead of throwing:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+When the left side does have a value, `?.` behaves exactly like a normal `.`. You can chain several: `user.address?.street?.name` returns `undefined` as soon as any link is missing.
+
+# --instructions--
+
+Complete the code so that both lines print `undefined` instead of throwing an error, using optional chaining
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/en/javascript/nullability/7.md
+++ b/en/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Optional chaining is not limited to dot properties. There are two more forms.
+`?.[]` reads an element or a computed key only when the left side has a value:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` calls a function only when it exists, which is handy for optional callbacks:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In every form, the check applies to the value **right before** the `?.`: `post?.tags?.[0]` is safe even when `post` itself is `null` or `undefined`.
+
+# --instructions--
+
+Write a function `firstTag(post)` that returns the first element of `post.tags`, or `undefined` when `post` is missing, has no `tags`, or its `tags` array is empty, using optional chaining instead of `if` statements
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` must return `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` must return `undefined`, because there is no `tags` property.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` must return `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` and `firstTag(undefined)` must return `undefined` without throwing.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+The function must use optional chaining and no `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/en/javascript/nullability/8.md
+++ b/en/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Once you know a value may be missing, you usually want a **default** in its place. Two operators do that, and they differ in what they consider "missing".
+`a || b` returns `b` whenever `a` is **falsy**: not only `null` and `undefined`, but also `0`, `""`, `false` and `NaN`.
+The **nullish coalescing** operator `a ?? b` returns `b` only when `a` is `null` or `undefined`, and keeps every other value:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` when `0`, `""` or `false` are legitimate values that must be kept, and `||` when you really want to replace every falsy value.
+
+# --instructions--
+
+Complete the code so that the first line keeps the `0` stored in `count`, the second line replaces the empty `name` with `"Guest"`, and the third line keeps the value `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/en/javascript/nullability/9.md
+++ b/en/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+A very common pattern is "fill in this property only if it is not set yet". Written with `??` it repeats the name:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+The **nullish assignment** operator `??=` does the same in one step: it assigns the right side only when the left side is currently `null` or `undefined`, and leaves any other value untouched:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` stays `0` because `0` is not nullish; `timeout` did not exist, so it receives `1000`. The same idea exists for `||` as `||=`, which overwrites every falsy value.
+
+# --instructions--
+
+What does this code print?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/en/javascript/nullability/_theory.md
+++ b/en/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript has two different ways to say "there is no value here".
+`undefined` means that a value was **never provided**. A variable declared without a value holds `undefined`, and so does a property that does not exist in an object:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` is a value that **you** assign on purpose to say "empty, and I know it":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+So `undefined` is usually the language telling you that something is missing, while `null` is the programmer stating that something is intentionally empty.
+
+---
+
+Functions produce `undefined` in two more situations.
+When you call a function with **fewer arguments** than it declares, the missing parameters hold `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+When a function finishes **without a `return`** (or with a bare `return;`), calling it gives `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notice that passing `null` explicitly is not the same as omitting the argument: `greet(null)` prints `null`, because `null` is a real value that was handed to the function.
+
+---
+
+The `typeof` operator returns the type of a value as a string. For `undefined` it answers `"undefined"`, as you would expect:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+For `null`, however, it answers `"object"`. This is a bug from the very first version of JavaScript that was never fixed, because too much code depends on it:
+```javascript
+console.log(typeof null);
+// prints object
+```
+So `typeof` is a reliable way to detect `undefined`, but not `null`. To check for `null`, compare with it directly: `value === null`.
+
+---
+
+How do `null` and `undefined` compare with each other? It depends on the operator.
+The **loose** equality `==` treats them as the same thing, and considers them different from any other value, including `0`, `""` and `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+The **strict** equality `===` also compares the type, and `null` and `undefined` have different types:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+Most of the time you do not care *which* of the two "no value" markers you got: you just want to know whether a value is there.
+Because `null == undefined` is `true` and nothing else is loosely equal to `null`, the comparison `value == null` is the standard idiom to catch **both** at once:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+This is the one case where `==` is preferred over `===`: writing `value === null || value === undefined` does exactly the same job, only longer.
+Values such as `0`, `""` and `false` are *not* `null`: they are real values that happen to be falsy.
+
+---
+
+Reading a property of `null` or `undefined` is an error that stops the program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` is `undefined`, and `undefined` has no properties. The **optional chaining** operator `?.` solves this: if the value on its left is `null` or `undefined`, the whole expression stops and evaluates to `undefined` instead of throwing:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+When the left side does have a value, `?.` behaves exactly like a normal `.`. You can chain several: `user.address?.street?.name` returns `undefined` as soon as any link is missing.
+
+---
+
+Optional chaining is not limited to dot properties. There are two more forms.
+`?.[]` reads an element or a computed key only when the left side has a value:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` calls a function only when it exists, which is handy for optional callbacks:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In every form, the check applies to the value **right before** the `?.`: `post?.tags?.[0]` is safe even when `post` itself is `null` or `undefined`.
+
+---
+
+Once you know a value may be missing, you usually want a **default** in its place. Two operators do that, and they differ in what they consider "missing".
+`a || b` returns `b` whenever `a` is **falsy**: not only `null` and `undefined`, but also `0`, `""`, `false` and `NaN`.
+The **nullish coalescing** operator `a ?? b` returns `b` only when `a` is `null` or `undefined`, and keeps every other value:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` when `0`, `""` or `false` are legitimate values that must be kept, and `||` when you really want to replace every falsy value.
+
+---
+
+A very common pattern is "fill in this property only if it is not set yet". Written with `??` it repeats the name:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+The **nullish assignment** operator `??=` does the same in one step: it assigns the right side only when the left side is currently `null` or `undefined`, and leaves any other value untouched:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` stays `0` because `0` is not nullish; `timeout` did not exist, so it receives `1000`. The same idea exists for `||` as `||=`, which overwrites every falsy value.
+
+---
+
+A **default parameter** gives a parameter a value when the caller does not provide one. The rule is precise: the default is used only when the argument is `undefined`, which includes omitting it. Passing `null` does **not** trigger the default, because `null` is a value:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Default parameters follow the `undefined` rule, while `??` covers both `null` and `undefined`: choose the one that matches how your function will be called.
+
+---
+
+Optional chaining and the `== null` guard work well together: the chain reads the nested value without throwing, and the guard decides what to do when the result is missing:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Inside the last `return` a plain `.` is safe, because the guard has already proven that every link exists.
+
+---
+
+Many built-in methods report "nothing found" by returning `undefined`. The array method `find(callback)` is the typical example: it returns the first element for which the callback is `true`, or `undefined` when no element matches:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Reading `found.price` here would throw, so `?.` and `??` are the natural companions of `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` and `undefined` behave differently when an object is converted to JSON with `JSON.stringify()`.
+JSON has a `null` value but no `undefined`, so a property whose value is `undefined` is simply **left out**, while a `null` property is kept:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Inside arrays the positions cannot disappear, so `undefined` becomes `null` there:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Checking `obj.key === undefined` cannot tell two situations apart: the property does not exist, or it exists and holds the value `undefined`.
+`Object.hasOwn(obj, key)` answers the first question only: it returns `true` when the object has its **own** property named `key`, whatever its value:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Own" means declared on the object itself: inherited members such as `toString` are available on every object but `Object.hasOwn(config, "toString")` is `false`.

--- a/es/javascript/data.json
+++ b/es/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Funciones Flecha",
         "description": "Aprende cómo escribir funciones anónimas cortas"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nulabilidad",
+        "description": "Aprende cómo manejar valores que pueden ser null o undefined"
     }
 }

--- a/es/javascript/nullability/1.md
+++ b/es/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript tiene dos formas distintas de decir "aquí no hay ningún valor".
+`undefined` significa que un valor **nunca fue proporcionado**. Una variable declarada sin valor contiene `undefined`, y también una propiedad que no existe en un objeto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` es un valor que **tú** asignas a propósito para decir "vacío, y lo sé":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Así que `undefined` suele ser el lenguaje diciéndote que algo falta, mientras que `null` es el programador afirmando que algo está vacío a propósito.
+
+# --instructions--
+
+Completa el código para que `city` se declare sin valor y `owner` se establezca explícitamente en `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/es/javascript/nullability/10.md
+++ b/es/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Un **parámetro por defecto** le da a un parámetro un valor cuando quien llama no proporciona uno. La regla es precisa: el valor por defecto se usa solo cuando el argumento es `undefined`, lo cual incluye omitirlo. Pasar `null` **no** activa el valor por defecto, porque `null` es un valor:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Los parámetros por defecto siguen la regla de `undefined`, mientras que `??` cubre tanto `null` como `undefined`: elige el que coincida con cómo se llamará tu función.
+
+# --instructions--
+
+Escribe una función `pad(text, width = 5)` que devuelva `text` seguido de tantos caracteres `"."` como sean necesarios para alcanzar `width` caracteres, usando un parámetro por defecto para `width`; cuando `text` ya tiene `width` caracteres o más, devuélvelo sin cambios
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` debe devolver `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` debe devolver `"ab..."`, usando el ancho por defecto de `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` también debe usar el ancho por defecto.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` debe devolver `"ab"`, porque `null` no activa el valor por defecto y se convierte a `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` debe devolver `"abcdef"` sin cambios.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` debe declararse como un parámetro por defecto.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/es/javascript/nullability/11.md
+++ b/es/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+El encadenamiento opcional y la comprobación `== null` funcionan bien juntos: la cadena lee el valor anidado sin lanzar un error, y la comprobación decide qué hacer cuando el resultado falta:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro del último `return` un `.` normal es seguro, porque la comprobación ya ha demostrado que cada eslabón existe.
+
+# --instructions--
+
+Ordena las líneas para definir `cityOf`, que devuelve `"unknown"` cuando el usuario no tiene ciudad y la ciudad en caso contrario, luego imprime el resultado para un usuario sin dirección y para un usuario que vive en `Rome`. Define primero la función
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/es/javascript/nullability/12.md
+++ b/es/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Muchos métodos integrados informan de "nada encontrado" devolviendo `undefined`. El método de arrays `find(callback)` es el ejemplo típico: devuelve el primer elemento para el cual el callback es `true`, o `undefined` cuando ningún elemento coincide:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Leer `found.price` aquí lanzaría un error, así que `?.` y `??` son los compañeros naturales de `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Escribe una función `priceOf(products, name)` que devuelva el `price` del producto de `products` cuyo `name` coincida, o `null` cuando no hay tal producto, usando `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` debe devolver `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` debe devolver `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` debe devolver `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` debe devolver `0`, no `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+La función debe usar `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/es/javascript/nullability/13.md
+++ b/es/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` y `undefined` se comportan de forma diferente cuando un objeto se convierte a JSON con `JSON.stringify()`.
+JSON tiene un valor `null` pero no `undefined`, así que una propiedad cuyo valor es `undefined` simplemente se **omite**, mientras que una propiedad `null` se conserva:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro de los arrays las posiciones no pueden desaparecer, así que allí `undefined` se convierte en `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+¿Qué imprime este código?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/es/javascript/nullability/14.md
+++ b/es/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Comprobar `obj.key === undefined` no puede distinguir dos situaciones: la propiedad no existe, o existe y contiene el valor `undefined`.
+`Object.hasOwn(obj, key)` responde solo a la primera pregunta: devuelve `true` cuando el objeto tiene su propiedad **propia** llamada `key`, sea cual sea su valor:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Propia" significa declarada en el objeto mismo: los miembros heredados como `toString` están disponibles en todos los objetos, pero `Object.hasOwn(config, "toString")` es `false`.
+
+# --instructions--
+
+Escribe una función `describeKey(obj, key)` que devuelva `"missing"` cuando `obj` no tiene la propiedad propia `key`, `"empty"` cuando la propiedad existe pero contiene `null` o `undefined`, y `"set"` en cualquier otro caso, usando `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` debe devolver `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` y `describeKey({ a: "" }, "a")` deben devolver `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` y `describeKey({ a: null }, "a")` deben devolver `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` debe devolver `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` debe devolver `"missing"`, porque `toString` es heredado, no propio.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+La función debe usar `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/es/javascript/nullability/15.md
+++ b/es/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Ordena las líneas para definir `finish`, que llama al callback opcional `onDone` de una tarea y devuelve su `name` o `"untitled"`, luego imprime el resultado para una tarea llamada `build` con un callback que imprime `done`, y para una tarea vacía. Define primero la función
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/es/javascript/nullability/16.md
+++ b/es/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Escribe una función `pick(obj, path, fallback)` donde `path` es una cadena de nombres de propiedades separados por puntos, como `"address.city"`; debe devolver el valor anidado encontrado siguiendo la ruta, o `fallback` cuando cualquier paso o el valor final es `null` o `undefined`; valores como `0`, `""` y `false` deben devolverse tal como son
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` debe devolver `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` debe devolver `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` debe devolver `0` sin lanzar un error.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` debe devolver `0` y `pick({ name: "" }, "name", "anon")` debe devolver `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` debe devolver `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` y `pick({ x: undefined }, "x", "none")` deben devolver `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/es/javascript/nullability/2.md
+++ b/es/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Las funciones producen `undefined` en dos situaciones más.
+Cuando llamas a una función con **menos argumentos** de los que declara, los parámetros que faltan contienen `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Cuando una función termina **sin un `return`** (o con un `return;` desnudo), llamarla da `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Fíjate en que pasar `null` explícitamente no es lo mismo que omitir el argumento: `greet(null)` imprime `null`, porque `null` es un valor real que se entregó a la función.
+
+# --instructions--
+
+Escribe una función `nameOrGuest(name)` que devuelva `"Guest"` cuando `name` sea `undefined` (por ejemplo porque el argumento se omitió) y devuelva `name` sin cambios en cualquier otro caso, incluido `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` debe devolver `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` debe devolver `"Guest"`, porque el argumento que falta es `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` debe devolver `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` debe devolver `null`, porque `null` es un valor que se pasó a propósito.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` debe devolver `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/es/javascript/nullability/3.md
+++ b/es/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+El operador `typeof` devuelve el tipo de un valor como una cadena. Para `undefined` responde `"undefined"`, como cabría esperar:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Para `null`, sin embargo, responde `"object"`. Este es un error de la primera versión de JavaScript que nunca se corrigió, porque demasiado código depende de él:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Así que `typeof` es una forma fiable de detectar `undefined`, pero no `null`. Para comprobar si hay `null`, compáralo directamente: `value === null`.
+
+# --instructions--
+
+¿Qué imprime este código?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/es/javascript/nullability/4.md
+++ b/es/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+¿Cómo se comparan `null` y `undefined` entre sí? Depende del operador.
+La igualdad **débil** `==` los trata como lo mismo, y los considera diferentes de cualquier otro valor, incluidos `0`, `""` y `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+La igualdad **estricta** `===` también compara el tipo, y `null` y `undefined` tienen tipos diferentes:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Completa el código para que la primera línea compare `missing` y `undefined` con la igualdad débil, la segunda con la igualdad estricta, y la tercera compruebe el resultado de `typeof missing`, produciendo la salida `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/es/javascript/nullability/5.md
+++ b/es/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+La mayoría de las veces no te importa *cuál* de los dos marcadores de "sin valor" recibiste: solo quieres saber si hay un valor.
+Como `null == undefined` es `true` y nada más es débilmente igual a `null`, la comparación `value == null` es la expresión idiomática estándar para capturar **ambos** a la vez:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Este es el único caso en el que se prefiere `==` sobre `===`: escribir `value === null || value === undefined` hace exactamente el mismo trabajo, solo que más largo.
+Valores como `0`, `""` y `false` *no* son `null`: son valores reales que resultan ser falsy.
+
+# --instructions--
+
+Escribe una función `isMissing(value)` que devuelva `true` cuando `value` sea `null` o `undefined`, y `false` para cualquier otro valor
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` debe devolver `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` e `isMissing()` deben devolver `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` debe devolver `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` e `isMissing(false)` deben devolver `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` e `isMissing({})` deben devolver `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/es/javascript/nullability/6.md
+++ b/es/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Leer una propiedad de `null` o `undefined` es un error que detiene el programa:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` es `undefined`, y `undefined` no tiene propiedades. El operador de **encadenamiento opcional** `?.` resuelve esto: si el valor a su izquierda es `null` o `undefined`, toda la expresión se detiene y evalúa a `undefined` en lugar de lanzar un error:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Cuando el lado izquierdo sí tiene un valor, `?.` se comporta exactamente como un `.` normal. Puedes encadenar varios: `user.address?.street?.name` devuelve `undefined` en cuanto falta cualquier eslabón.
+
+# --instructions--
+
+Completa el código para que ambas líneas impriman `undefined` en lugar de lanzar un error, usando el encadenamiento opcional
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/es/javascript/nullability/7.md
+++ b/es/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+El encadenamiento opcional no se limita a propiedades con punto. Hay dos formas más.
+`?.[]` lee un elemento o una clave calculada solo cuando el lado izquierdo tiene un valor:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` llama a una función solo cuando existe, lo cual es útil para callbacks opcionales:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+En todas las formas, la comprobación se aplica al valor situado **justo antes** del `?.`: `post?.tags?.[0]` es seguro incluso cuando `post` en sí es `null` o `undefined`.
+
+# --instructions--
+
+Escribe una función `firstTag(post)` que devuelva el primer elemento de `post.tags`, o `undefined` cuando `post` no existe, no tiene `tags`, o su array `tags` está vacío, usando encadenamiento opcional en lugar de sentencias `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` debe devolver `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` debe devolver `undefined`, porque no hay propiedad `tags`.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` debe devolver `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` y `firstTag(undefined)` deben devolver `undefined` sin lanzar un error.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+La función debe usar encadenamiento opcional y ningún `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/es/javascript/nullability/8.md
+++ b/es/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Una vez que sabes que un valor puede faltar, normalmente quieres un **valor por defecto** en su lugar. Dos operadores hacen eso, y se diferencian en qué consideran que "falta".
+`a || b` devuelve `b` siempre que `a` sea **falsy**: no solo `null` y `undefined`, sino también `0`, `""`, `false` y `NaN`.
+El operador de **coalescencia nula** `a ?? b` devuelve `b` solo cuando `a` es `null` o `undefined`, y conserva cualquier otro valor:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Usa `??` cuando `0`, `""` o `false` son valores legítimos que deben conservarse, y `||` cuando realmente quieras reemplazar cada valor falsy.
+
+# --instructions--
+
+Completa el código para que la primera línea conserve el `0` almacenado en `count`, la segunda línea reemplace el `name` vacío por `"Guest"`, y la tercera línea conserve el valor `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/es/javascript/nullability/9.md
+++ b/es/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Un patrón muy común es "rellenar esta propiedad solo si aún no está establecida". Escrito con `??` repite el nombre:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+El operador de **asignación con coalescencia nula** `??=` hace lo mismo en un paso: asigna el lado derecho solo cuando el lado izquierdo es actualmente `null` o `undefined`, y deja cualquier otro valor intacto:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` se queda en `0` porque `0` no es nullish; `timeout` no existía, así que recibe `1000`. La misma idea existe para `||` como `||=`, que sobrescribe cada valor falsy.
+
+# --instructions--
+
+¿Qué imprime este código?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/es/javascript/nullability/_theory.md
+++ b/es/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript tiene dos formas distintas de decir "aquí no hay ningún valor".
+`undefined` significa que un valor **nunca fue proporcionado**. Una variable declarada sin valor contiene `undefined`, y también una propiedad que no existe en un objeto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` es un valor que **tú** asignas a propósito para decir "vacío, y lo sé":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Así que `undefined` suele ser el lenguaje diciéndote que algo falta, mientras que `null` es el programador afirmando que algo está vacío a propósito.
+
+---
+
+Las funciones producen `undefined` en dos situaciones más.
+Cuando llamas a una función con **menos argumentos** de los que declara, los parámetros que faltan contienen `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Cuando una función termina **sin un `return`** (o con un `return;` desnudo), llamarla da `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Fíjate en que pasar `null` explícitamente no es lo mismo que omitir el argumento: `greet(null)` imprime `null`, porque `null` es un valor real que se entregó a la función.
+
+---
+
+El operador `typeof` devuelve el tipo de un valor como una cadena. Para `undefined` responde `"undefined"`, como cabría esperar:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Para `null`, sin embargo, responde `"object"`. Este es un error de la primera versión de JavaScript que nunca se corrigió, porque demasiado código depende de él:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Así que `typeof` es una forma fiable de detectar `undefined`, pero no `null`. Para comprobar si hay `null`, compáralo directamente: `value === null`.
+
+---
+
+¿Cómo se comparan `null` y `undefined` entre sí? Depende del operador.
+La igualdad **débil** `==` los trata como lo mismo, y los considera diferentes de cualquier otro valor, incluidos `0`, `""` y `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+La igualdad **estricta** `===` también compara el tipo, y `null` y `undefined` tienen tipos diferentes:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+La mayoría de las veces no te importa *cuál* de los dos marcadores de "sin valor" recibiste: solo quieres saber si hay un valor.
+Como `null == undefined` es `true` y nada más es débilmente igual a `null`, la comparación `value == null` es la expresión idiomática estándar para capturar **ambos** a la vez:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Este es el único caso en el que se prefiere `==` sobre `===`: escribir `value === null || value === undefined` hace exactamente el mismo trabajo, solo que más largo.
+Valores como `0`, `""` y `false` *no* son `null`: son valores reales que resultan ser falsy.
+
+---
+
+Leer una propiedad de `null` o `undefined` es un error que detiene el programa:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` es `undefined`, y `undefined` no tiene propiedades. El operador de **encadenamiento opcional** `?.` resuelve esto: si el valor a su izquierda es `null` o `undefined`, toda la expresión se detiene y evalúa a `undefined` en lugar de lanzar un error:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Cuando el lado izquierdo sí tiene un valor, `?.` se comporta exactamente como un `.` normal. Puedes encadenar varios: `user.address?.street?.name` devuelve `undefined` en cuanto falta cualquier eslabón.
+
+---
+
+El encadenamiento opcional no se limita a propiedades con punto. Hay dos formas más.
+`?.[]` lee un elemento o una clave calculada solo cuando el lado izquierdo tiene un valor:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` llama a una función solo cuando existe, lo cual es útil para callbacks opcionales:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+En todas las formas, la comprobación se aplica al valor situado **justo antes** del `?.`: `post?.tags?.[0]` es seguro incluso cuando `post` en sí es `null` o `undefined`.
+
+---
+
+Una vez que sabes que un valor puede faltar, normalmente quieres un **valor por defecto** en su lugar. Dos operadores hacen eso, y se diferencian en qué consideran que "falta".
+`a || b` devuelve `b` siempre que `a` sea **falsy**: no solo `null` y `undefined`, sino también `0`, `""`, `false` y `NaN`.
+El operador de **coalescencia nula** `a ?? b` devuelve `b` solo cuando `a` es `null` o `undefined`, y conserva cualquier otro valor:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Usa `??` cuando `0`, `""` o `false` son valores legítimos que deben conservarse, y `||` cuando realmente quieras reemplazar cada valor falsy.
+
+---
+
+Un patrón muy común es "rellenar esta propiedad solo si aún no está establecida". Escrito con `??` repite el nombre:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+El operador de **asignación con coalescencia nula** `??=` hace lo mismo en un paso: asigna el lado derecho solo cuando el lado izquierdo es actualmente `null` o `undefined`, y deja cualquier otro valor intacto:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` se queda en `0` porque `0` no es nullish; `timeout` no existía, así que recibe `1000`. La misma idea existe para `||` como `||=`, que sobrescribe cada valor falsy.
+
+---
+
+Un **parámetro por defecto** le da a un parámetro un valor cuando quien llama no proporciona uno. La regla es precisa: el valor por defecto se usa solo cuando el argumento es `undefined`, lo cual incluye omitirlo. Pasar `null` **no** activa el valor por defecto, porque `null` es un valor:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Los parámetros por defecto siguen la regla de `undefined`, mientras que `??` cubre tanto `null` como `undefined`: elige el que coincida con cómo se llamará tu función.
+
+---
+
+El encadenamiento opcional y la comprobación `== null` funcionan bien juntos: la cadena lee el valor anidado sin lanzar un error, y la comprobación decide qué hacer cuando el resultado falta:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro del último `return` un `.` normal es seguro, porque la comprobación ya ha demostrado que cada eslabón existe.
+
+---
+
+Muchos métodos integrados informan de "nada encontrado" devolviendo `undefined`. El método de arrays `find(callback)` es el ejemplo típico: devuelve el primer elemento para el cual el callback es `true`, o `undefined` cuando ningún elemento coincide:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Leer `found.price` aquí lanzaría un error, así que `?.` y `??` son los compañeros naturales de `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` y `undefined` se comportan de forma diferente cuando un objeto se convierte a JSON con `JSON.stringify()`.
+JSON tiene un valor `null` pero no `undefined`, así que una propiedad cuyo valor es `undefined` simplemente se **omite**, mientras que una propiedad `null` se conserva:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro de los arrays las posiciones no pueden desaparecer, así que allí `undefined` se convierte en `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Comprobar `obj.key === undefined` no puede distinguir dos situaciones: la propiedad no existe, o existe y contiene el valor `undefined`.
+`Object.hasOwn(obj, key)` responde solo a la primera pregunta: devuelve `true` cuando el objeto tiene su propiedad **propia** llamada `key`, sea cual sea su valor:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Propia" significa declarada en el objeto mismo: los miembros heredados como `toString` están disponibles en todos los objetos, pero `Object.hasOwn(config, "toString")` es `false`.

--- a/fr/javascript/data.json
+++ b/fr/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Fonctions fléchées",
         "description": "Apprenez à écrire des fonctions anonymes courtes"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullabilité",
+        "description": "Apprenez à gérer les valeurs qui peuvent être null ou undefined"
     }
 }

--- a/fr/javascript/nullability/1.md
+++ b/fr/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript possède deux façons différentes de dire « il n'y a pas de valeur ici ».
+`undefined` signifie qu'une valeur n'a **jamais été fournie**. Une variable déclarée sans valeur contient `undefined`, et il en va de même pour une propriété qui n'existe pas dans un objet :
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` est une valeur que **vous** assignez délibérément pour dire « vide, et je le sais » :
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Donc `undefined` est généralement le langage qui vous signale qu'il manque quelque chose, tandis que `null` est le programmeur qui déclare que quelque chose est intentionnellement vide.
+
+# --instructions--
+
+Complétez le code pour que `city` soit déclarée sans valeur et que `owner` soit explicitement défini à `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/fr/javascript/nullability/10.md
+++ b/fr/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Un **paramètre par défaut** donne une valeur à un paramètre quand l'appelant n'en fournit pas. La règle est précise : la valeur par défaut n'est utilisée que lorsque l'argument est `undefined`, ce qui inclut son omission. Passer `null` ne déclenche **pas** la valeur par défaut, car `null` est une valeur :
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Les paramètres par défaut suivent la règle du `undefined`, tandis que `??` couvre à la fois `null` et `undefined` : choisissez celui qui correspond à la façon dont votre fonction sera appelée.
+
+# --instructions--
+
+Écrivez une fonction `pad(text, width = 5)` qui renvoie `text` suivi d'autant de caractères `"."` que nécessaire pour atteindre `width` caractères, en utilisant un paramètre par défaut pour `width` ; quand `text` fait déjà `width` caractères ou plus, renvoyez-le inchangé
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` doit renvoyer `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` doit renvoyer `"ab..."`, en utilisant la largeur par défaut de `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` doit également utiliser la largeur par défaut.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` doit renvoyer `"ab"`, car `null` ne déclenche pas la valeur par défaut et est converti en `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` doit renvoyer `"abcdef"` inchangé.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` doit être déclaré comme paramètre par défaut.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/fr/javascript/nullability/11.md
+++ b/fr/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Le chaînage optionnel et la garde `== null` fonctionnent bien ensemble : la chaîne lit la valeur imbriquée sans lever d'erreur, et la garde décide quoi faire quand le résultat est absent :
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dans le dernier `return`, un simple `.` est sûr, car la garde a déjà prouvé que chaque maillon existe.
+
+# --instructions--
+
+Triez les lignes pour définir `cityOf`, qui renvoie `"unknown"` quand l'utilisateur n'a pas de ville et la ville sinon, puis affichez le résultat pour un utilisateur sans adresse et pour un utilisateur vivant à `Rome`. Définissez d'abord la fonction
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/fr/javascript/nullability/12.md
+++ b/fr/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+De nombreuses méthodes intégrées signalent « rien trouvé » en renvoyant `undefined`. La méthode de tableau `find(callback)` en est l'exemple typique : elle renvoie le premier élément pour lequel le callback vaut `true`, ou `undefined` quand aucun élément ne correspond :
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Lire `found.price` ici lèverait une erreur, donc `?.` et `??` sont les compagnons naturels de `find` :
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Écrivez une fonction `priceOf(products, name)` qui renvoie le `price` du produit de `products` dont le `name` correspond, ou `null` quand un tel produit n'existe pas, en utilisant `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` doit renvoyer `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` doit renvoyer `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` doit renvoyer `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` doit renvoyer `0`, pas `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+La fonction doit utiliser `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/fr/javascript/nullability/13.md
+++ b/fr/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` et `undefined` se comportent différemment quand un objet est converti en JSON avec `JSON.stringify()`.
+Le JSON possède une valeur `null` mais pas d'`undefined`, donc une propriété dont la valeur est `undefined` est simplement **omise**, tandis qu'une propriété `null` est conservée :
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dans les tableaux, les positions ne peuvent pas disparaître, donc `undefined` y devient `null` :
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+Qu'affiche ce code ?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/fr/javascript/nullability/14.md
+++ b/fr/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Vérifier `obj.key === undefined` ne permet pas de distinguer deux situations : la propriété n'existe pas, ou elle existe et contient la valeur `undefined`.
+`Object.hasOwn(obj, key)` répond uniquement à la première question : il renvoie `true` quand l'objet possède sa **propre** propriété nommée `key`, quelle que soit sa valeur :
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+« Propre » signifie déclarée sur l'objet lui-même : les membres hérités tels que `toString` sont disponibles sur chaque objet, mais `Object.hasOwn(config, "toString")` vaut `false`.
+
+# --instructions--
+
+Écrivez une fonction `describeKey(obj, key)` qui renvoie `"missing"` quand `obj` n'a pas de propriété propre `key`, `"empty"` quand la propriété existe mais contient `null` ou `undefined`, et `"set"` dans tous les autres cas, en utilisant `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` doit renvoyer `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` et `describeKey({ a: "" }, "a")` doivent renvoyer `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` et `describeKey({ a: null }, "a")` doivent renvoyer `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` doit renvoyer `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` doit renvoyer `"missing"`, car `toString` est hérité et non propre.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+La fonction doit utiliser `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/fr/javascript/nullability/15.md
+++ b/fr/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Triez les lignes pour définir `finish`, qui appelle le callback `onDone` optionnel d'une tâche et renvoie son `name` ou `"untitled"`, puis affichez le résultat pour une tâche nommée `build` avec un callback affichant `done`, et pour une tâche vide. Définissez d'abord la fonction
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/fr/javascript/nullability/16.md
+++ b/fr/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Écrivez une fonction `pick(obj, path, fallback)` où `path` est une chaîne de noms de propriétés séparés par des points, comme `"address.city"` ; elle doit renvoyer la valeur imbriquée trouvée en suivant le chemin, ou `fallback` quand une étape ou la valeur finale vaut `null` ou `undefined` ; des valeurs comme `0`, `""` et `false` doivent être renvoyées telles quelles
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` doit renvoyer `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` doit renvoyer `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` doit renvoyer `0` sans lever d'erreur.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` doit renvoyer `0` et `pick({ name: "" }, "name", "anon")` doit renvoyer `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` doit renvoyer `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` et `pick({ x: undefined }, "x", "none")` doivent renvoyer `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/fr/javascript/nullability/2.md
+++ b/fr/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Les fonctions produisent `undefined` dans deux autres situations.
+Quand vous appelez une fonction avec **moins d'arguments** qu'elle n'en déclare, les paramètres manquants valent `undefined` :
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quand une fonction se termine **sans `return`** (ou avec un simple `return;`), l'appeler donne `undefined` :
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notez que passer `null` explicitement n'est pas la même chose que d'omettre l'argument : `greet(null)` affiche `null`, car `null` est une véritable valeur qui a été transmise à la fonction.
+
+# --instructions--
+
+Écrivez une fonction `nameOrGuest(name)` qui renvoie `"Guest"` quand `name` est `undefined` (par exemple parce que l'argument a été omis) et renvoie `name` inchangé dans tous les autres cas, y compris `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` doit renvoyer `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` doit renvoyer `"Guest"`, car l'argument manquant est `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` doit renvoyer `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` doit renvoyer `null`, car `null` est une valeur qui a été passée intentionnellement.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` doit renvoyer `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/fr/javascript/nullability/3.md
+++ b/fr/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+L'opérateur `typeof` renvoie le type d'une valeur sous forme de chaîne. Pour `undefined`, il répond `"undefined"`, comme on pourrait s'y attendre :
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Pour `null`, en revanche, il répond `"object"`. C'est un bug présent depuis la toute première version de JavaScript et qui n'a jamais été corrigé, car trop de code en dépend :
+```javascript
+console.log(typeof null);
+// prints object
+```
+`typeof` est donc un moyen fiable de détecter `undefined`, mais pas `null`. Pour vérifier `null`, comparez directement avec lui : `value === null`.
+
+# --instructions--
+
+Qu'affiche ce code ?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/fr/javascript/nullability/4.md
+++ b/fr/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Comment `null` et `undefined` se comparent-ils entre eux ? Cela dépend de l'opérateur.
+L'égalité **faible** `==` les considère comme la même chose, et les juge différents de toute autre valeur, y compris `0`, `""` et `false` :
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+L'égalité **stricte** `===` compare également le type, et `null` et `undefined` ont des types différents :
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Complétez le code pour que la première ligne compare `missing` et `undefined` avec l'égalité faible, la deuxième avec l'égalité stricte, et que la troisième vérifie le résultat de `typeof missing`, produisant la sortie `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/fr/javascript/nullability/5.md
+++ b/fr/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+La plupart du temps, peu importe *laquelle* des deux marques « pas de valeur » vous avez reçue : vous voulez simplement savoir si une valeur est présente.
+Comme `null == undefined` vaut `true` et que rien d'autre n'est faiblement égal à `null`, la comparaison `value == null` est l'idiome standard pour détecter **les deux** d'un coup :
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+C'est le seul cas où `==` est préféré à `===` : écrire `value === null || value === undefined` fait exactement le même travail, seulement plus long.
+Des valeurs comme `0`, `""` et `false` ne sont *pas* `null` : ce sont de véritables valeurs qui se trouvent être falsy.
+
+# --instructions--
+
+Écrivez une fonction `isMissing(value)` qui renvoie `true` quand `value` est `null` ou `undefined`, et `false` pour toute autre valeur
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` doit renvoyer `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` et `isMissing()` doivent renvoyer `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` doit renvoyer `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` et `isMissing(false)` doivent renvoyer `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` et `isMissing({})` doivent renvoyer `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/fr/javascript/nullability/6.md
+++ b/fr/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Lire une propriété de `null` ou `undefined` est une erreur qui arrête le programme :
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` est `undefined`, et `undefined` n'a pas de propriétés. L'opérateur de **chaînage optionnel** `?.` résout ce problème : si la valeur à sa gauche est `null` ou `undefined`, toute l'expression s'arrête et vaut `undefined` au lieu de lever une erreur :
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quand le côté gauche a bien une valeur, `?.` se comporte exactement comme un `.` normal. Vous pouvez en chaîner plusieurs : `user.address?.street?.name` renvoie `undefined` dès qu'un maillon manque.
+
+# --instructions--
+
+Complétez le code pour que les deux lignes affichent `undefined` au lieu de lever une erreur, en utilisant le chaînage optionnel
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/fr/javascript/nullability/7.md
+++ b/fr/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Le chaînage optionnel ne se limite pas aux propriétés avec un point. Il existe deux autres formes.
+`?.[]` lit un élément ou une clé calculée seulement quand le côté gauche a une valeur :
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` appelle une fonction seulement quand elle existe, ce qui est pratique pour les callbacks optionnels :
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+Dans toutes les formes, la vérification s'applique à la valeur **juste avant** le `?.` : `post?.tags?.[0]` est sûr même quand `post` lui-même est `null` ou `undefined`.
+
+# --instructions--
+
+Écrivez une fonction `firstTag(post)` qui renvoie le premier élément de `post.tags`, ou `undefined` quand `post` est absent, n'a pas de `tags`, ou que son tableau `tags` est vide, en utilisant le chaînage optionnel au lieu d'instructions `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` doit renvoyer `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` doit renvoyer `undefined`, car il n'y a pas de propriété `tags`.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` doit renvoyer `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` et `firstTag(undefined)` doivent renvoyer `undefined` sans lever d'erreur.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+La fonction doit utiliser le chaînage optionnel et aucun `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/fr/javascript/nullability/8.md
+++ b/fr/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Une fois que vous savez qu'une valeur peut être absente, vous voulez généralement une valeur **par défaut** à sa place. Deux opérateurs font cela, et ils diffèrent par ce qu'ils considèrent comme « absent ».
+`a || b` renvoie `b` dès que `a` est **falsy** : pas seulement `null` et `undefined`, mais aussi `0`, `""`, `false` et `NaN`.
+L'opérateur de **coalescence nullish** `a ?? b` renvoie `b` seulement quand `a` est `null` ou `undefined`, et conserve toute autre valeur :
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Utilisez `??` quand `0`, `""` ou `false` sont des valeurs légitimes qui doivent être conservées, et `||` quand vous voulez vraiment remplacer toute valeur falsy.
+
+# --instructions--
+
+Complétez le code pour que la première ligne conserve le `0` stocké dans `count`, que la deuxième remplace le `name` vide par `"Guest"`, et que la troisième conserve la valeur `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/fr/javascript/nullability/9.md
+++ b/fr/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Un motif très courant est « remplir cette propriété seulement si elle n'est pas encore définie ». Écrit avec `??`, il répète le nom :
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+L'opérateur d'**affectation nullish** `??=` fait la même chose en une étape : il affecte le côté droit seulement quand le côté gauche vaut actuellement `null` ou `undefined`, et laisse toute autre valeur intacte :
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` reste `0` car `0` n'est pas nullish ; `timeout` n'existait pas, il reçoit donc `1000`. La même idée existe pour `||` sous la forme `||=`, qui écrase toute valeur falsy.
+
+# --instructions--
+
+Qu'affiche ce code ?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/fr/javascript/nullability/_theory.md
+++ b/fr/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript possède deux façons différentes de dire « il n'y a pas de valeur ici ».
+`undefined` signifie qu'une valeur n'a **jamais été fournie**. Une variable déclarée sans valeur contient `undefined`, et il en va de même pour une propriété qui n'existe pas dans un objet :
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` est une valeur que **vous** assignez délibérément pour dire « vide, et je le sais » :
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Donc `undefined` est généralement le langage qui vous signale qu'il manque quelque chose, tandis que `null` est le programmeur qui déclare que quelque chose est intentionnellement vide.
+
+---
+
+Les fonctions produisent `undefined` dans deux autres situations.
+Quand vous appelez une fonction avec **moins d'arguments** qu'elle n'en déclare, les paramètres manquants valent `undefined` :
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quand une fonction se termine **sans `return`** (ou avec un simple `return;`), l'appeler donne `undefined` :
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notez que passer `null` explicitement n'est pas la même chose que d'omettre l'argument : `greet(null)` affiche `null`, car `null` est une véritable valeur qui a été transmise à la fonction.
+
+---
+
+L'opérateur `typeof` renvoie le type d'une valeur sous forme de chaîne. Pour `undefined`, il répond `"undefined"`, comme on pourrait s'y attendre :
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Pour `null`, en revanche, il répond `"object"`. C'est un bug présent depuis la toute première version de JavaScript et qui n'a jamais été corrigé, car trop de code en dépend :
+```javascript
+console.log(typeof null);
+// prints object
+```
+`typeof` est donc un moyen fiable de détecter `undefined`, mais pas `null`. Pour vérifier `null`, comparez directement avec lui : `value === null`.
+
+---
+
+Comment `null` et `undefined` se comparent-ils entre eux ? Cela dépend de l'opérateur.
+L'égalité **faible** `==` les considère comme la même chose, et les juge différents de toute autre valeur, y compris `0`, `""` et `false` :
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+L'égalité **stricte** `===` compare également le type, et `null` et `undefined` ont des types différents :
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+La plupart du temps, peu importe *laquelle* des deux marques « pas de valeur » vous avez reçue : vous voulez simplement savoir si une valeur est présente.
+Comme `null == undefined` vaut `true` et que rien d'autre n'est faiblement égal à `null`, la comparaison `value == null` est l'idiome standard pour détecter **les deux** d'un coup :
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+C'est le seul cas où `==` est préféré à `===` : écrire `value === null || value === undefined` fait exactement le même travail, seulement plus long.
+Des valeurs comme `0`, `""` et `false` ne sont *pas* `null` : ce sont de véritables valeurs qui se trouvent être falsy.
+
+---
+
+Lire une propriété de `null` ou `undefined` est une erreur qui arrête le programme :
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` est `undefined`, et `undefined` n'a pas de propriétés. L'opérateur de **chaînage optionnel** `?.` résout ce problème : si la valeur à sa gauche est `null` ou `undefined`, toute l'expression s'arrête et vaut `undefined` au lieu de lever une erreur :
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quand le côté gauche a bien une valeur, `?.` se comporte exactement comme un `.` normal. Vous pouvez en chaîner plusieurs : `user.address?.street?.name` renvoie `undefined` dès qu'un maillon manque.
+
+---
+
+Le chaînage optionnel ne se limite pas aux propriétés avec un point. Il existe deux autres formes.
+`?.[]` lit un élément ou une clé calculée seulement quand le côté gauche a une valeur :
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` appelle une fonction seulement quand elle existe, ce qui est pratique pour les callbacks optionnels :
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+Dans toutes les formes, la vérification s'applique à la valeur **juste avant** le `?.` : `post?.tags?.[0]` est sûr même quand `post` lui-même est `null` ou `undefined`.
+
+---
+
+Une fois que vous savez qu'une valeur peut être absente, vous voulez généralement une valeur **par défaut** à sa place. Deux opérateurs font cela, et ils diffèrent par ce qu'ils considèrent comme « absent ».
+`a || b` renvoie `b` dès que `a` est **falsy** : pas seulement `null` et `undefined`, mais aussi `0`, `""`, `false` et `NaN`.
+L'opérateur de **coalescence nullish** `a ?? b` renvoie `b` seulement quand `a` est `null` ou `undefined`, et conserve toute autre valeur :
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Utilisez `??` quand `0`, `""` ou `false` sont des valeurs légitimes qui doivent être conservées, et `||` quand vous voulez vraiment remplacer toute valeur falsy.
+
+---
+
+Un motif très courant est « remplir cette propriété seulement si elle n'est pas encore définie ». Écrit avec `??`, il répète le nom :
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+L'opérateur d'**affectation nullish** `??=` fait la même chose en une étape : il affecte le côté droit seulement quand le côté gauche vaut actuellement `null` ou `undefined`, et laisse toute autre valeur intacte :
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` reste `0` car `0` n'est pas nullish ; `timeout` n'existait pas, il reçoit donc `1000`. La même idée existe pour `||` sous la forme `||=`, qui écrase toute valeur falsy.
+
+---
+
+Un **paramètre par défaut** donne une valeur à un paramètre quand l'appelant n'en fournit pas. La règle est précise : la valeur par défaut n'est utilisée que lorsque l'argument est `undefined`, ce qui inclut son omission. Passer `null` ne déclenche **pas** la valeur par défaut, car `null` est une valeur :
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Les paramètres par défaut suivent la règle du `undefined`, tandis que `??` couvre à la fois `null` et `undefined` : choisissez celui qui correspond à la façon dont votre fonction sera appelée.
+
+---
+
+Le chaînage optionnel et la garde `== null` fonctionnent bien ensemble : la chaîne lit la valeur imbriquée sans lever d'erreur, et la garde décide quoi faire quand le résultat est absent :
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dans le dernier `return`, un simple `.` est sûr, car la garde a déjà prouvé que chaque maillon existe.
+
+---
+
+De nombreuses méthodes intégrées signalent « rien trouvé » en renvoyant `undefined`. La méthode de tableau `find(callback)` en est l'exemple typique : elle renvoie le premier élément pour lequel le callback vaut `true`, ou `undefined` quand aucun élément ne correspond :
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Lire `found.price` ici lèverait une erreur, donc `?.` et `??` sont les compagnons naturels de `find` :
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` et `undefined` se comportent différemment quand un objet est converti en JSON avec `JSON.stringify()`.
+Le JSON possède une valeur `null` mais pas d'`undefined`, donc une propriété dont la valeur est `undefined` est simplement **omise**, tandis qu'une propriété `null` est conservée :
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dans les tableaux, les positions ne peuvent pas disparaître, donc `undefined` y devient `null` :
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Vérifier `obj.key === undefined` ne permet pas de distinguer deux situations : la propriété n'existe pas, ou elle existe et contient la valeur `undefined`.
+`Object.hasOwn(obj, key)` répond uniquement à la première question : il renvoie `true` quand l'objet possède sa **propre** propriété nommée `key`, quelle que soit sa valeur :
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+« Propre » signifie déclarée sur l'objet lui-même : les membres hérités tels que `toString` sont disponibles sur chaque objet, mais `Object.hasOwn(config, "toString")` vaut `false`.

--- a/hi/javascript/data.json
+++ b/hi/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "एरो फंक्शन्स",
         "description": "छोटे अनाम फंक्शन्स लिखना सीखें"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "नलेबिलिटी",
+        "description": "`null` या `undefined` हो सकने वाले मानों को संभालना सीखें"
     }
 }

--- a/hi/javascript/nullability/1.md
+++ b/hi/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript में "यहाँ कोई मान नहीं है" कहने के दो अलग-अलग तरीके हैं।
+`undefined` का मतलब है कि कोई मान **कभी दिया ही नहीं गया**। बिना मान के घोषित किया गया वेरिएबल `undefined` रखता है, और किसी ऑब्जेक्ट में मौजूद न होने वाली प्रॉपर्टी भी ऐसा ही करती है:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` एक ऐसा मान है जिसे **आप** जानबूझकर असाइन करते हैं ताकि यह बता सकें कि "खाली है, और मुझे पता है":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+So `undefined` is usually the language telling you that something is missing, while `null` is the programmer stating that something is intentionally empty.
+
+# --instructions--
+
+Complete the code so that `city` is declared without a value and `owner` is explicitly set to `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/hi/javascript/nullability/10.md
+++ b/hi/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+A **default parameter** gives a parameter a value when the caller does not provide one. The rule is precise: the default is used only when the argument is `undefined`, which includes omitting it. Passing `null` does **not** trigger the default, because `null` is a value:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Default parameters follow the `undefined` rule, while `??` covers both `null` and `undefined`: choose the one that matches how your function will be called.
+
+# --instructions--
+
+Write a function `pad(text, width = 5)` that returns `text` followed by as many `"."` characters as needed to reach `width` characters, using a default parameter for `width`; when `text` is already `width` characters or longer, return it unchanged
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` must return `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` must return `"ab..."`, using the default width of `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` must also use the default width.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` must return `"ab"`, because `null` does not trigger the default and is converted to `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` must return `"abcdef"` unchanged.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` must be declared as a default parameter.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/hi/javascript/nullability/11.md
+++ b/hi/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Optional chaining and the `== null` guard work well together: the chain reads the nested value without throwing, and the guard decides what to do when the result is missing:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Inside the last `return` a plain `.` is safe, because the guard has already proven that every link exists.
+
+# --instructions--
+
+Sort the lines to define `cityOf`, which returns `"unknown"` when the user has no city and the city otherwise, then print the result for a user without an address and for a user living in `Rome`. Define the function first
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/hi/javascript/nullability/12.md
+++ b/hi/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Many built-in methods report "nothing found" by returning `undefined`. The array method `find(callback)` is the typical example: it returns the first element for which the callback is `true`, or `undefined` when no element matches:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Reading `found.price` here would throw, so `?.` and `??` are the natural companions of `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Write a function `priceOf(products, name)` that returns the `price` of the product of `products` whose `name` matches, or `null` when there is no such product, using `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` must return `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` must return `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` must return `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` must return `0`, not `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+The function must use `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/hi/javascript/nullability/13.md
+++ b/hi/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` and `undefined` behave differently when an object is converted to JSON with `JSON.stringify()`.
+JSON has a `null` value but no `undefined`, so a property whose value is `undefined` is simply **left out**, while a `null` property is kept:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Inside arrays the positions cannot disappear, so `undefined` becomes `null` there:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+What does this code print?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/hi/javascript/nullability/14.md
+++ b/hi/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Checking `obj.key === undefined` cannot tell two situations apart: the property does not exist, or it exists and holds the value `undefined`.
+`Object.hasOwn(obj, key)` answers the first question only: it returns `true` when the object has its **own** property named `key`, whatever its value:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Own" means declared on the object itself: inherited members such as `toString` are available on every object but `Object.hasOwn(config, "toString")` is `false`.
+
+# --instructions--
+
+Write a function `describeKey(obj, key)` that returns `"missing"` when `obj` has no own property `key`, `"empty"` when the property exists but holds `null` or `undefined`, and `"set"` in every other case, using `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` must return `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` and `describeKey({ a: "" }, "a")` must return `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` and `describeKey({ a: null }, "a")` must return `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` must return `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` must return `"missing"`, because `toString` is inherited, not own.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+The function must use `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/hi/javascript/nullability/15.md
+++ b/hi/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Sort the lines to define `finish`, which calls the optional `onDone` callback of a task and returns its `name` or `"untitled"`, then print the result for a task named `build` with a callback printing `done`, and for an empty task. Define the function first
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/hi/javascript/nullability/16.md
+++ b/hi/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Write a function `pick(obj, path, fallback)` where `path` is a string of property names separated by dots, such as `"address.city"`; it must return the nested value found by following the path, or `fallback` when any step or the final value is `null` or `undefined`; values such as `0`, `""` and `false` must be returned as they are
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` must return `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` must return `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` must return `0` without throwing.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` must return `0` and `pick({ name: "" }, "name", "anon")` must return `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` must return `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` and `pick({ x: undefined }, "x", "none")` must return `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/hi/javascript/nullability/2.md
+++ b/hi/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Functions produce `undefined` in two more situations.
+When you call a function with **fewer arguments** than it declares, the missing parameters hold `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+When a function finishes **without a `return`** (or with a bare `return;`), calling it gives `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notice that passing `null` explicitly is not the same as omitting the argument: `greet(null)` prints `null`, because `null` is a real value that was handed to the function.
+
+# --instructions--
+
+Write a function `nameOrGuest(name)` that returns `"Guest"` when `name` is `undefined` (for example because the argument was omitted) and returns `name` unchanged in every other case, including `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` must return `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` must return `"Guest"`, because the missing argument is `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` must return `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` must return `null`, because `null` is a value that was passed on purpose.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` must return `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/hi/javascript/nullability/3.md
+++ b/hi/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+The `typeof` operator returns the type of a value as a string. For `undefined` it answers `"undefined"`, as you would expect:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+For `null`, however, it answers `"object"`. This is a bug from the very first version of JavaScript that was never fixed, because too much code depends on it:
+```javascript
+console.log(typeof null);
+// prints object
+```
+So `typeof` is a reliable way to detect `undefined`, but not `null`. To check for `null`, compare with it directly: `value === null`.
+
+# --instructions--
+
+What does this code print?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/hi/javascript/nullability/4.md
+++ b/hi/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+How do `null` and `undefined` compare with each other? It depends on the operator.
+The **loose** equality `==` treats them as the same thing, and considers them different from any other value, including `0`, `""` and `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+The **strict** equality `===` also compares the type, and `null` and `undefined` have different types:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Complete the code so that the first line compares `missing` and `undefined` with the loose equality, the second line with the strict equality, and the third line checks the result of `typeof missing`, producing the output `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/hi/javascript/nullability/5.md
+++ b/hi/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Most of the time you do not care *which* of the two "no value" markers you got: you just want to know whether a value is there.
+Because `null == undefined` is `true` and nothing else is loosely equal to `null`, the comparison `value == null` is the standard idiom to catch **both** at once:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+This is the one case where `==` is preferred over `===`: writing `value === null || value === undefined` does exactly the same job, only longer.
+Values such as `0`, `""` and `false` are *not* `null`: they are real values that happen to be falsy.
+
+# --instructions--
+
+Write a function `isMissing(value)` that returns `true` when `value` is `null` or `undefined`, and `false` for any other value
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` must return `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` and `isMissing()` must return `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` must return `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` and `isMissing(false)` must return `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` and `isMissing({})` must return `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/hi/javascript/nullability/6.md
+++ b/hi/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Reading a property of `null` or `undefined` is an error that stops the program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` is `undefined`, and `undefined` has no properties. The **optional chaining** operator `?.` solves this: if the value on its left is `null` or `undefined`, the whole expression stops and evaluates to `undefined` instead of throwing:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+When the left side does have a value, `?.` behaves exactly like a normal `.`. You can chain several: `user.address?.street?.name` returns `undefined` as soon as any link is missing.
+
+# --instructions--
+
+Complete the code so that both lines print `undefined` instead of throwing an error, using optional chaining
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/hi/javascript/nullability/7.md
+++ b/hi/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Optional chaining is not limited to dot properties. There are two more forms.
+`?.[]` reads an element or a computed key only when the left side has a value:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` calls a function only when it exists, which is handy for optional callbacks:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In every form, the check applies to the value **right before** the `?.`: `post?.tags?.[0]` is safe even when `post` itself is `null` or `undefined`.
+
+# --instructions--
+
+Write a function `firstTag(post)` that returns the first element of `post.tags`, or `undefined` when `post` is missing, has no `tags`, or its `tags` array is empty, using optional chaining instead of `if` statements
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` must return `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` must return `undefined`, because there is no `tags` property.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` must return `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` and `firstTag(undefined)` must return `undefined` without throwing.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+The function must use optional chaining and no `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/hi/javascript/nullability/8.md
+++ b/hi/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Once you know a value may be missing, you usually want a **default** in its place. Two operators do that, and they differ in what they consider "missing".
+`a || b` returns `b` whenever `a` is **falsy**: not only `null` and `undefined`, but also `0`, `""`, `false` and `NaN`.
+The **nullish coalescing** operator `a ?? b` returns `b` only when `a` is `null` or `undefined`, and keeps every other value:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` when `0`, `""` or `false` are legitimate values that must be kept, and `||` when you really want to replace every falsy value.
+
+# --instructions--
+
+Complete the code so that the first line keeps the `0` stored in `count`, the second line replaces the empty `name` with `"Guest"`, and the third line keeps the value `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/hi/javascript/nullability/9.md
+++ b/hi/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+A very common pattern is "fill in this property only if it is not set yet". Written with `??` it repeats the name:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+The **nullish assignment** operator `??=` does the same in one step: it assigns the right side only when the left side is currently `null` or `undefined`, and leaves any other value untouched:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` stays `0` because `0` is not nullish; `timeout` did not exist, so it receives `1000`. The same idea exists for `||` as `||=`, which overwrites every falsy value.
+
+# --instructions--
+
+What does this code print?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/hi/javascript/nullability/_theory.md
+++ b/hi/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript में "यहाँ कोई मान नहीं है" कहने के दो अलग-अलग तरीके हैं।
+`undefined` का मतलब है कि कोई मान **कभी दिया ही नहीं गया**। बिना मान के घोषित किया गया वेरिएबल `undefined` रखता है, और किसी ऑब्जेक्ट में मौजूद न होने वाली प्रॉपर्टी भी ऐसा ही करती है:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` एक ऐसा मान है जिसे **आप** जानबूझकर असाइन करते हैं ताकि यह बता सकें कि "खाली है, और मुझे पता है":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+So `undefined` is usually the language telling you that something is missing, while `null` is the programmer stating that something is intentionally empty.
+
+---
+
+Functions produce `undefined` in two more situations.
+When you call a function with **fewer arguments** than it declares, the missing parameters hold `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+When a function finishes **without a `return`** (or with a bare `return;`), calling it gives `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Notice that passing `null` explicitly is not the same as omitting the argument: `greet(null)` prints `null`, because `null` is a real value that was handed to the function.
+
+---
+
+The `typeof` operator returns the type of a value as a string. For `undefined` it answers `"undefined"`, as you would expect:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+For `null`, however, it answers `"object"`. This is a bug from the very first version of JavaScript that was never fixed, because too much code depends on it:
+```javascript
+console.log(typeof null);
+// prints object
+```
+So `typeof` is a reliable way to detect `undefined`, but not `null`. To check for `null`, compare with it directly: `value === null`.
+
+---
+
+How do `null` and `undefined` compare with each other? It depends on the operator.
+The **loose** equality `==` treats them as the same thing, and considers them different from any other value, including `0`, `""` and `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+The **strict** equality `===` also compares the type, and `null` and `undefined` have different types:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+Most of the time you do not care *which* of the two "no value" markers you got: you just want to know whether a value is there.
+Because `null == undefined` is `true` and nothing else is loosely equal to `null`, the comparison `value == null` is the standard idiom to catch **both** at once:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+This is the one case where `==` is preferred over `===`: writing `value === null || value === undefined` does exactly the same job, only longer.
+Values such as `0`, `""` and `false` are *not* `null`: they are real values that happen to be falsy.
+
+---
+
+Reading a property of `null` or `undefined` is an error that stops the program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` is `undefined`, and `undefined` has no properties. The **optional chaining** operator `?.` solves this: if the value on its left is `null` or `undefined`, the whole expression stops and evaluates to `undefined` instead of throwing:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+When the left side does have a value, `?.` behaves exactly like a normal `.`. You can chain several: `user.address?.street?.name` returns `undefined` as soon as any link is missing.
+
+---
+
+Optional chaining is not limited to dot properties. There are two more forms.
+`?.[]` reads an element or a computed key only when the left side has a value:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` calls a function only when it exists, which is handy for optional callbacks:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In every form, the check applies to the value **right before** the `?.`: `post?.tags?.[0]` is safe even when `post` itself is `null` or `undefined`.
+
+---
+
+Once you know a value may be missing, you usually want a **default** in its place. Two operators do that, and they differ in what they consider "missing".
+`a || b` returns `b` whenever `a` is **falsy**: not only `null` and `undefined`, but also `0`, `""`, `false` and `NaN`.
+The **nullish coalescing** operator `a ?? b` returns `b` only when `a` is `null` or `undefined`, and keeps every other value:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` when `0`, `""` or `false` are legitimate values that must be kept, and `||` when you really want to replace every falsy value.
+
+---
+
+A very common pattern is "fill in this property only if it is not set yet". Written with `??` it repeats the name:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+The **nullish assignment** operator `??=` does the same in one step: it assigns the right side only when the left side is currently `null` or `undefined`, and leaves any other value untouched:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` stays `0` because `0` is not nullish; `timeout` did not exist, so it receives `1000`. The same idea exists for `||` as `||=`, which overwrites every falsy value.
+
+---
+
+A **default parameter** gives a parameter a value when the caller does not provide one. The rule is precise: the default is used only when the argument is `undefined`, which includes omitting it. Passing `null` does **not** trigger the default, because `null` is a value:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Default parameters follow the `undefined` rule, while `??` covers both `null` and `undefined`: choose the one that matches how your function will be called.
+
+---
+
+Optional chaining and the `== null` guard work well together: the chain reads the nested value without throwing, and the guard decides what to do when the result is missing:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Inside the last `return` a plain `.` is safe, because the guard has already proven that every link exists.
+
+---
+
+Many built-in methods report "nothing found" by returning `undefined`. The array method `find(callback)` is the typical example: it returns the first element for which the callback is `true`, or `undefined` when no element matches:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Reading `found.price` here would throw, so `?.` and `??` are the natural companions of `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` and `undefined` behave differently when an object is converted to JSON with `JSON.stringify()`.
+JSON has a `null` value but no `undefined`, so a property whose value is `undefined` is simply **left out**, while a `null` property is kept:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Inside arrays the positions cannot disappear, so `undefined` becomes `null` there:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Checking `obj.key === undefined` cannot tell two situations apart: the property does not exist, or it exists and holds the value `undefined`.
+`Object.hasOwn(obj, key)` answers the first question only: it returns `true` when the object has its **own** property named `key`, whatever its value:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Own" means declared on the object itself: inherited members such as `toString` are available on every object but `Object.hasOwn(config, "toString")` is `false`.

--- a/it/javascript/data.json
+++ b/it/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Funzioni Freccia",
         "description": "Impara a scrivere funzioni anonime brevi"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullabilità",
+        "description": "Impara a gestire i valori che possono essere null o undefined"
     }
 }

--- a/it/javascript/nullability/1.md
+++ b/it/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript ha due modi diversi per dire "qui non c'è alcun valore".
+`undefined` significa che un valore **non è mai stato fornito**. Una variabile dichiarata senza valore contiene `undefined`, e lo stesso vale per una proprietà che non esiste in un oggetto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` è un valore che **tu** assegni di proposito per dire "vuoto, e lo so":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Quindi `undefined` è di solito il linguaggio che ti dice che manca qualcosa, mentre `null` è il programmatore che dichiara che qualcosa è volutamente vuoto.
+
+# --instructions--
+
+Completa il codice in modo che `city` sia dichiarata senza valore e `owner` sia impostato esplicitamente a `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/it/javascript/nullability/10.md
+++ b/it/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Un **parametro predefinito** assegna a un parametro un valore quando chi chiama non ne fornisce uno. La regola è precisa: il valore predefinito è usato solo quando l'argomento è `undefined`, il che include il caso in cui viene omesso. Passare `null` **non** attiva il valore predefinito, perché `null` è un valore:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+I parametri predefiniti seguono la regola dell'`undefined`, mentre `??` copre sia `null` che `undefined`: scegli quello che corrisponde a come la tua funzione verrà chiamata.
+
+# --instructions--
+
+Scrivi una funzione `pad(text, width = 5)` che restituisca `text` seguito da quanti caratteri `"."` servono per raggiungere `width` caratteri, usando un parametro predefinito per `width`; quando `text` è già lungo `width` caratteri o più, restituiscilo invariato
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` deve restituire `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` deve restituire `"ab..."`, usando la larghezza predefinita di `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` deve usare anch'essa la larghezza predefinita.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` deve restituire `"ab"`, perché `null` non attiva il valore predefinito e viene convertito in `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` deve restituire `"abcdef"` invariato.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` deve essere dichiarato come parametro predefinito.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/it/javascript/nullability/11.md
+++ b/it/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+L'optional chaining e il controllo `== null` lavorano bene insieme: la catena legge il valore annidato senza lanciare errori, e il controllo decide cosa fare quando il risultato manca:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro l'ultimo `return` un normale `.` è sicuro, perché il controllo ha già provato che ogni anello esiste.
+
+# --instructions--
+
+Ordina le righe per definire `cityOf`, che restituisce `"unknown"` quando l'utente non ha una città e la città altrimenti, poi stampa il risultato per un utente senza indirizzo e per un utente che vive a `Rome`. Definisci prima la funzione
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/it/javascript/nullability/12.md
+++ b/it/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Molti metodi integrati segnalano "niente trovato" restituendo `undefined`. Il metodo degli array `find(callback)` è l'esempio tipico: restituisce il primo elemento per cui il callback è `true`, oppure `undefined` quando nessun elemento corrisponde:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Leggere `found.price` qui lancerebbe un errore, quindi `?.` e `??` sono i compagni naturali di `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Scrivi una funzione `priceOf(products, name)` che restituisca il `price` del prodotto di `products` il cui `name` corrisponde, oppure `null` quando non c'è un tale prodotto, usando `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` deve restituire `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` deve restituire `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` deve restituire `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` deve restituire `0`, non `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+La funzione deve usare `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/it/javascript/nullability/13.md
+++ b/it/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` e `undefined` si comportano diversamente quando un oggetto viene convertito in JSON con `JSON.stringify()`.
+Il JSON ha un valore `null` ma niente `undefined`, quindi una proprietà il cui valore è `undefined` viene semplicemente **omessa**, mentre una proprietà `null` viene conservata:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro gli array le posizioni non possono sparire, quindi lì `undefined` diventa `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+Cosa stampa questo codice?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/it/javascript/nullability/14.md
+++ b/it/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Controllare `obj.key === undefined` non può distinguere due situazioni: la proprietà non esiste, oppure esiste e contiene il valore `undefined`.
+`Object.hasOwn(obj, key)` risponde solo alla prima domanda: restituisce `true` quando l'oggetto ha una proprietà **propria** chiamata `key`, qualunque sia il suo valore:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Propria" significa dichiarata sull'oggetto stesso: i membri ereditati come `toString` sono disponibili su ogni oggetto ma `Object.hasOwn(config, "toString")` è `false`.
+
+# --instructions--
+
+Scrivi una funzione `describeKey(obj, key)` che restituisca `"missing"` quando `obj` non ha la proprietà propria `key`, `"empty"` quando la proprietà esiste ma contiene `null` o `undefined`, e `"set"` in tutti gli altri casi, usando `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` deve restituire `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` e `describeKey({ a: "" }, "a")` devono restituire `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` e `describeKey({ a: null }, "a")` devono restituire `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` deve restituire `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` deve restituire `"missing"`, perché `toString` è ereditato, non proprio.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+La funzione deve usare `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/it/javascript/nullability/15.md
+++ b/it/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Ordina le righe per definire `finish`, che chiama il callback opzionale `onDone` di un task e restituisce il suo `name` oppure `"untitled"`, poi stampa il risultato per un task chiamato `build` con un callback che stampa `done`, e per un task vuoto. Definisci prima la funzione
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/it/javascript/nullability/16.md
+++ b/it/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Scrivi una funzione `pick(obj, path, fallback)` dove `path` è una stringa di nomi di proprietà separati da punti, come `"address.city"`; deve restituire il valore annidato trovato seguendo il percorso, oppure `fallback` quando un qualsiasi passaggio o il valore finale è `null` o `undefined`; valori come `0`, `""` e `false` devono essere restituiti così come sono
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` deve restituire `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` deve restituire `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` deve restituire `0` senza lanciare errori.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` deve restituire `0` e `pick({ name: "" }, "name", "anon")` deve restituire `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` deve restituire `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` e `pick({ x: undefined }, "x", "none")` devono restituire `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/it/javascript/nullability/2.md
+++ b/it/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Le funzioni producono `undefined` in altre due situazioni.
+Quando chiami una funzione con **meno argomenti** di quanti ne dichiara, i parametri mancanti contengono `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quando una funzione termina **senza un `return`** (o con un semplice `return;`), chiamarla restituisce `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Nota che passare `null` esplicitamente non è la stessa cosa che omettere l'argomento: `greet(null)` stampa `null`, perché `null` è un valore reale che è stato passato alla funzione.
+
+# --instructions--
+
+Scrivi una funzione `nameOrGuest(name)` che restituisca `"Guest"` quando `name` è `undefined` (ad esempio perché l'argomento è stato omesso) e restituisca `name` invariato in tutti gli altri casi, incluso `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` deve restituire `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` deve restituire `"Guest"`, perché l'argomento mancante è `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` deve restituire `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` deve restituire `null`, perché `null` è un valore che è stato passato di proposito.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` deve restituire `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/it/javascript/nullability/3.md
+++ b/it/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+L'operatore `typeof` restituisce il tipo di un valore come stringa. Per `undefined` risponde `"undefined"`, come ti aspetteresti:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Per `null`, invece, risponde `"object"`. Questo è un bug della primissima versione di JavaScript che non è mai stato corretto, perché troppo codice dipende da esso:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Quindi `typeof` è un modo affidabile per rilevare `undefined`, ma non `null`. Per controllare `null`, confronta direttamente con esso: `value === null`.
+
+# --instructions--
+
+Cosa stampa questo codice?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/it/javascript/nullability/4.md
+++ b/it/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Come si confrontano tra loro `null` e `undefined`? Dipende dall'operatore.
+L'uguaglianza **lasca** `==` li tratta come la stessa cosa, e li considera diversi da qualsiasi altro valore, incluso `0`, `""` e `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+L'uguaglianza **stretta** `===` confronta anche il tipo, e `null` e `undefined` hanno tipi diversi:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Completa il codice in modo che la prima riga confronti `missing` e `undefined` con l'uguaglianza lasca, la seconda con l'uguaglianza stretta, e la terza controlli il risultato di `typeof missing`, producendo l'output `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/it/javascript/nullability/5.md
+++ b/it/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Nella maggior parte dei casi non ti interessa *quale* dei due marcatori di "assenza di valore" hai ricevuto: vuoi solo sapere se c'è un valore.
+Poiché `null == undefined` è `true` e nessun altro valore è lascamente uguale a `null`, il confronto `value == null` è l'idioma standard per intercettare **entrambi** in una volta:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Questo è l'unico caso in cui `==` è preferito a `===`: scrivere `value === null || value === undefined` fa esattamente lo stesso lavoro, solo più lungo.
+Valori come `0`, `""` e `false` *non* sono `null`: sono valori reali che per caso sono falsy.
+
+# --instructions--
+
+Scrivi una funzione `isMissing(value)` che restituisca `true` quando `value` è `null` o `undefined`, e `false` per qualsiasi altro valore
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` deve restituire `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` e `isMissing()` devono restituire `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` deve restituire `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` e `isMissing(false)` devono restituire `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` e `isMissing({})` devono restituire `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/it/javascript/nullability/6.md
+++ b/it/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Leggere una proprietà di `null` o `undefined` è un errore che ferma il programma:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` è `undefined`, e `undefined` non ha proprietà. L'operatore di **optional chaining** `?.` risolve questo problema: se il valore alla sua sinistra è `null` o `undefined`, l'intera espressione si ferma e vale `undefined` invece di lanciare un errore:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quando il lato sinistro ha un valore, `?.` si comporta esattamente come un normale `.`. Puoi concatenarne diversi: `user.address?.street?.name` restituisce `undefined` non appena manca un qualsiasi anello.
+
+# --instructions--
+
+Completa il codice in modo che entrambe le righe stampino `undefined` invece di lanciare un errore, usando l'optional chaining
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/it/javascript/nullability/7.md
+++ b/it/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+L'optional chaining non è limitato alle proprietà con il punto. Esistono altre due forme.
+`?.[]` legge un elemento o una chiave calcolata solo quando il lato sinistro ha un valore:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` chiama una funzione solo quando esiste, il che è utile per i callback opzionali:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In ogni forma, il controllo si applica al valore **immediatamente prima** del `?.`: `post?.tags?.[0]` è sicuro anche quando `post` stesso è `null` o `undefined`.
+
+# --instructions--
+
+Scrivi una funzione `firstTag(post)` che restituisca il primo elemento di `post.tags`, oppure `undefined` quando `post` manca, non ha `tags`, o il suo array `tags` è vuoto, usando l'optional chaining invece di istruzioni `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` deve restituire `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` deve restituire `undefined`, perché non c'è la proprietà `tags`.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` deve restituire `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` e `firstTag(undefined)` devono restituire `undefined` senza lanciare errori.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+La funzione deve usare l'optional chaining e nessun `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/it/javascript/nullability/8.md
+++ b/it/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Una volta che sai che un valore può mancare, di solito vuoi un **predefinito** al suo posto. Due operatori lo fanno, e differiscono in ciò che considerano "mancante".
+`a || b` restituisce `b` ogni volta che `a` è **falsy**: non solo `null` e `undefined`, ma anche `0`, `""`, `false` e `NaN`.
+L'operatore di **nullish coalescing** `a ?? b` restituisce `b` solo quando `a` è `null` o `undefined`, e conserva ogni altro valore:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Usa `??` quando `0`, `""` o `false` sono valori legittimi che devono essere conservati, e `||` quando vuoi davvero sostituire ogni valore falsy.
+
+# --instructions--
+
+Completa il codice in modo che la prima riga conservi lo `0` memorizzato in `count`, la seconda riga sostituisca la `name` vuota con `"Guest"`, e la terza riga conservi il valore `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/it/javascript/nullability/9.md
+++ b/it/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Uno schema molto comune è "compila questa proprietà solo se non è ancora impostata". Scritto con `??` ripete il nome:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+L'operatore di **nullish assignment** `??=` fa la stessa cosa in un solo passo: assegna il lato destro solo quando il lato sinistro è attualmente `null` o `undefined`, e lascia intatto qualsiasi altro valore:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` resta `0` perché `0` non è nullish; `timeout` non esisteva, quindi riceve `1000`. La stessa idea esiste per `||` come `||=`, che sovrascrive ogni valore falsy.
+
+# --instructions--
+
+Cosa stampa questo codice?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/it/javascript/nullability/_theory.md
+++ b/it/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript ha due modi diversi per dire "qui non c'è alcun valore".
+`undefined` significa che un valore **non è mai stato fornito**. Una variabile dichiarata senza valore contiene `undefined`, e lo stesso vale per una proprietà che non esiste in un oggetto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` è un valore che **tu** assegni di proposito per dire "vuoto, e lo so":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Quindi `undefined` è di solito il linguaggio che ti dice che manca qualcosa, mentre `null` è il programmatore che dichiara che qualcosa è volutamente vuoto.
+
+---
+
+Le funzioni producono `undefined` in altre due situazioni.
+Quando chiami una funzione con **meno argomenti** di quanti ne dichiara, i parametri mancanti contengono `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quando una funzione termina **senza un `return`** (o con un semplice `return;`), chiamarla restituisce `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Nota che passare `null` esplicitamente non è la stessa cosa che omettere l'argomento: `greet(null)` stampa `null`, perché `null` è un valore reale che è stato passato alla funzione.
+
+---
+
+L'operatore `typeof` restituisce il tipo di un valore come stringa. Per `undefined` risponde `"undefined"`, come ti aspetteresti:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Per `null`, invece, risponde `"object"`. Questo è un bug della primissima versione di JavaScript che non è mai stato corretto, perché troppo codice dipende da esso:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Quindi `typeof` è un modo affidabile per rilevare `undefined`, ma non `null`. Per controllare `null`, confronta direttamente con esso: `value === null`.
+
+---
+
+Come si confrontano tra loro `null` e `undefined`? Dipende dall'operatore.
+L'uguaglianza **lasca** `==` li tratta come la stessa cosa, e li considera diversi da qualsiasi altro valore, incluso `0`, `""` e `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+L'uguaglianza **stretta** `===` confronta anche il tipo, e `null` e `undefined` hanno tipi diversi:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+Nella maggior parte dei casi non ti interessa *quale* dei due marcatori di "assenza di valore" hai ricevuto: vuoi solo sapere se c'è un valore.
+Poiché `null == undefined` è `true` e nessun altro valore è lascamente uguale a `null`, il confronto `value == null` è l'idioma standard per intercettare **entrambi** in una volta:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Questo è l'unico caso in cui `==` è preferito a `===`: scrivere `value === null || value === undefined` fa esattamente lo stesso lavoro, solo più lungo.
+Valori come `0`, `""` e `false` *non* sono `null`: sono valori reali che per caso sono falsy.
+
+---
+
+Leggere una proprietà di `null` o `undefined` è un errore che ferma il programma:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` è `undefined`, e `undefined` non ha proprietà. L'operatore di **optional chaining** `?.` risolve questo problema: se il valore alla sua sinistra è `null` o `undefined`, l'intera espressione si ferma e vale `undefined` invece di lanciare un errore:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quando il lato sinistro ha un valore, `?.` si comporta esattamente come un normale `.`. Puoi concatenarne diversi: `user.address?.street?.name` restituisce `undefined` non appena manca un qualsiasi anello.
+
+---
+
+L'optional chaining non è limitato alle proprietà con il punto. Esistono altre due forme.
+`?.[]` legge un elemento o una chiave calcolata solo quando il lato sinistro ha un valore:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` chiama una funzione solo quando esiste, il che è utile per i callback opzionali:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+In ogni forma, il controllo si applica al valore **immediatamente prima** del `?.`: `post?.tags?.[0]` è sicuro anche quando `post` stesso è `null` o `undefined`.
+
+---
+
+Una volta che sai che un valore può mancare, di solito vuoi un **predefinito** al suo posto. Due operatori lo fanno, e differiscono in ciò che considerano "mancante".
+`a || b` restituisce `b` ogni volta che `a` è **falsy**: non solo `null` e `undefined`, ma anche `0`, `""`, `false` e `NaN`.
+L'operatore di **nullish coalescing** `a ?? b` restituisce `b` solo quando `a` è `null` o `undefined`, e conserva ogni altro valore:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Usa `??` quando `0`, `""` o `false` sono valori legittimi che devono essere conservati, e `||` quando vuoi davvero sostituire ogni valore falsy.
+
+---
+
+Uno schema molto comune è "compila questa proprietà solo se non è ancora impostata". Scritto con `??` ripete il nome:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+L'operatore di **nullish assignment** `??=` fa la stessa cosa in un solo passo: assegna il lato destro solo quando il lato sinistro è attualmente `null` o `undefined`, e lascia intatto qualsiasi altro valore:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` resta `0` perché `0` non è nullish; `timeout` non esisteva, quindi riceve `1000`. La stessa idea esiste per `||` come `||=`, che sovrascrive ogni valore falsy.
+
+---
+
+Un **parametro predefinito** assegna a un parametro un valore quando chi chiama non ne fornisce uno. La regola è precisa: il valore predefinito è usato solo quando l'argomento è `undefined`, il che include il caso in cui viene omesso. Passare `null` **non** attiva il valore predefinito, perché `null` è un valore:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+I parametri predefiniti seguono la regola dell'`undefined`, mentre `??` copre sia `null` che `undefined`: scegli quello che corrisponde a come la tua funzione verrà chiamata.
+
+---
+
+L'optional chaining e il controllo `== null` lavorano bene insieme: la catena legge il valore annidato senza lanciare errori, e il controllo decide cosa fare quando il risultato manca:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro l'ultimo `return` un normale `.` è sicuro, perché il controllo ha già provato che ogni anello esiste.
+
+---
+
+Molti metodi integrati segnalano "niente trovato" restituendo `undefined`. Il metodo degli array `find(callback)` è l'esempio tipico: restituisce il primo elemento per cui il callback è `true`, oppure `undefined` quando nessun elemento corrisponde:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Leggere `found.price` qui lancerebbe un errore, quindi `?.` e `??` sono i compagni naturali di `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` e `undefined` si comportano diversamente quando un oggetto viene convertito in JSON con `JSON.stringify()`.
+Il JSON ha un valore `null` ma niente `undefined`, quindi una proprietà il cui valore è `undefined` viene semplicemente **omessa**, mentre una proprietà `null` viene conservata:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro gli array le posizioni non possono sparire, quindi lì `undefined` diventa `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Controllare `obj.key === undefined` non può distinguere due situazioni: la proprietà non esiste, oppure esiste e contiene il valore `undefined`.
+`Object.hasOwn(obj, key)` risponde solo alla prima domanda: restituisce `true` quando l'oggetto ha una proprietà **propria** chiamata `key`, qualunque sia il suo valore:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Propria" significa dichiarata sull'oggetto stesso: i membri ereditati come `toString` sono disponibili su ogni oggetto ma `Object.hasOwn(config, "toString")` è `false`.

--- a/ja/javascript/data.json
+++ b/ja/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "アロー関数",
         "description": "短い匿名関数を書く方法を学ぶ"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "null可能性",
+        "description": "nullまたはundefinedの可能性がある値を扱う方法を学ぶ"
     }
 }

--- a/ja/javascript/nullability/1.md
+++ b/ja/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScriptには「ここには値がない」ことを表す方法が2つあります。
+`undefined`は値が**一度も提供されていない**ことを意味します。値なしで宣言された変数は`undefined`を持ち、オブジェクトに存在しないプロパティも同様です:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null`は「空であることを、自分はわかっている」と意図的にあなたが代入する値です:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+つまり`undefined`は通常、何かが欠けていることを言語が伝えているものであり、`null`はプログラマーが何かを意図的に空にしていることを示すものです。
+
+# --instructions--
+
+`city`が値なしで宣言され、`owner`が明示的に`null`に設定されるようにコードを完成させてください
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/ja/javascript/nullability/10.md
+++ b/ja/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+**デフォルト引数**は、呼び出し側が値を提供しなかった場合に引数へ値を与えます。そのルールは正確です: デフォルトが使われるのは引数が`undefined`のときだけです。これは引数の省略も含みます。`null`を渡してもデフォルトは発動**しません**。`null`は値だからです:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+デフォルト引数は`undefined`のルールに従いますが、`??`は`null`と`undefined`の両方をカバーします: 関数がどのように呼ばれるかに合わせて選んでください。
+
+# --instructions--
+
+`width`にデフォルト引数を使い、`text`の後に`width`文字に達するまで必要な数の`"."`文字を続けて返す関数`pad(text, width = 5)`を書いてください; `text`がすでに`width`文字以上の場合は、そのまま返してください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` は `"ab.."` を返すべきです
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` はデフォルトの幅 `5` を使って `"ab..."` を返すべきです
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` もデフォルトの幅を使うべきです
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` は `"ab"` を返すべきです。`null`はデフォルトを発動させず、`0`に変換されるからです
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` は `"abcdef"` をそのまま返すべきです
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` はデフォルト引数として宣言されるべきです
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/ja/javascript/nullability/11.md
+++ b/ja/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+オプショナルチェーンと`== null`によるガードはうまく連携します: チェーンはネストした値をスローせずに読み、ガードは結果が欠けている場合の対処を決めます:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+最後の`return`の中ではプレーンな`.`が安全です。ガードがすべてのリンクの存在をすでに証明しているからです。
+
+# --instructions--
+
+行を並べ替えて、ユーザーに都市がない場合は`"unknown"`を返し、それ以外の場合はその都市を返す`cityOf`を定義し、次に住所のないユーザーと`Rome`に住むユーザーについて結果を出力してください。関数を最初に定義してください
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/ja/javascript/nullability/12.md
+++ b/ja/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+多くの組み込みメソッドは「何も見つからなかった」ことを`undefined`を返すことで報告します。配列メソッド`find(callback)`が典型的な例です: コールバックが`true`になる最初の要素を返し、一致する要素がない場合は`undefined`を返します:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+ここで`found.price`を読むとスローしてしまうため、`?.`と`??`は`find`の自然な相棒です:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+`find`を使って、`name`が一致する`products`内の製品の`price`を返し、そのような製品がない場合は`null`を返す関数`priceOf(products, name)`を書いてください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` は `7` を返すべきです
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` は `null` を返すべきです
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` は `null` を返すべきです
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` は `null` ではなく `0` を返すべきです
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+関数は `find` を使うべきです
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/ja/javascript/nullability/13.md
+++ b/ja/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null`と`undefined`は、`JSON.stringify()`でオブジェクトをJSONに変換するときに異なる動作をします。
+JSONには`null`という値はありますが`undefined`はありません。そのため、値が`undefined`のプロパティは単に**省かれ**、`null`のプロパティは保持されます:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+配列の中では位置を消すことができないため、そこでは`undefined`は`null`になります:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+次のコードは何を出力しますか？
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/ja/javascript/nullability/14.md
+++ b/ja/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+`obj.key === undefined`のチェックでは、2つの場面を区別できません: プロパティが存在しないのか、存在するが値として`undefined`を持っているのかです。
+`Object.hasOwn(obj, key)`は最初の疑問にのみ答えます: オブジェクトが`key`という名前の**自身の**プロパティを持っていれば、その値が何であれ`true`を返します:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+「自身の」とは、オブジェクト自体に宣言されたことを意味します: `toString`のような継承されたメンバーはすべてのオブジェクトで利用できますが、`Object.hasOwn(config, "toString")`は`false`です。
+
+# --instructions--
+
+`Object.hasOwn`を使って、`obj`が自身のプロパティ`key`を持たない場合は`"missing"`を、プロパティは存在するが`null`または`undefined`を保持している場合は`"empty"`を、その他の場合は`"set"`を返す関数`describeKey(obj, key)`を書いてください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` は `"set"` を返すべきです
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` と `describeKey({ a: "" }, "a")` は `"set"` を返すべきです
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` と `describeKey({ a: null }, "a")` は `"empty"` を返すべきです
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` は `"missing"` を返すべきです
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` は `"missing"` を返すべきです。`toString`は継承されたものであり、自身のプロパティではないからです
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+関数は `Object.hasOwn` を使うべきです
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/ja/javascript/nullability/15.md
+++ b/ja/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+行を並べ替えて、タスクのオプションの`onDone`コールバックを呼び出し、その`name`または`"untitled"`を返す`finish`を定義し、次に`done`を出力するコールバックを持つ`build`という名前のタスクと、空のタスクについて結果を出力してください。関数を最初に定義してください
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/ja/javascript/nullability/16.md
+++ b/ja/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+`path`が`"address.city"`のようにドットで区切られたプロパティ名の文字列である関数`pick(obj, path, fallback)`を書いてください; パスをたどって見つかったネストした値を返し、いずれかのステップまたは最終的な値が`null`または`undefined`のときは`fallback`を返さなければなりません; `0`、`""`、`false`などの値はそのまま返さなければなりません
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` は `"Rome"` を返すべきです
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` は `"unknown"` を返すべきです
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` はスローせずに `0` を返すべきです
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` は `0` を返し、`pick({ name: "" }, "name", "anon")` は `""` を返すべきです
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` は `false` を返すべきです
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` と `pick({ x: undefined }, "x", "none")` は `"none"` を返すべきです
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/ja/javascript/nullability/2.md
+++ b/ja/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+関数はさらに2つの場面で`undefined`を生み出します。
+宣言されているより**少ない引数**で関数を呼び出すと、欠けている引数は`undefined`になります:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+関数が**`return`なしで**(または`return;`のみで)終わると、呼び出しの結果は`undefined`になります:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+`null`を明示的に渡すことは引数を省略することと同じではないことに注意してください: `greet(null)`は`null`を出力します。`null`は関数に渡された実際の値だからです。
+
+# --instructions--
+
+`name`が`undefined`のとき(たとえば引数が省略された場合)に`"Guest"`を返し、それ以外の場合は`null`を含めて`name`をそのまま返す関数`nameOrGuest(name)`を書いてください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` は `"Ana"` を返すべきです
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` は `"Guest"` を返すべきです。欠けている引数は`undefined`だからです
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` は `"Guest"` を返すべきです
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` は `null` を返すべきです。`null`は意図的に渡された値だからです
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` は `""` を返すべきです
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/ja/javascript/nullability/3.md
+++ b/ja/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`typeof`演算子は値の型を文字列として返します。`undefined`に対しては期待どおり`"undefined"`と答えます:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+しかし`null`に対しては`"object"`と答えます。これはJavaScriptの最初のバージョンからのバグで、あまりに多くのコードがそれに依存しているため修正されることはありませんでした:
+```javascript
+console.log(typeof null);
+// prints object
+```
+したがって`typeof`は`undefined`を検出する確実な方法ですが、`null`の検出には使えません。`null`を調べるには、直接比較します: `value === null`。
+
+# --instructions--
+
+次のコードは何を出力しますか？
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/ja/javascript/nullability/4.md
+++ b/ja/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+`null`と`undefined`は互いにどのように比較されるのでしょうか？ それは演算子によります。
+**緩い**等価演算子`==`は両者を同じものとして扱い、`0`、`""`、`false`を含む他のどの値とも異なるものとみなします:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**厳密**等価演算子`===`は型も比較しますが、`null`と`undefined`は型が異なります:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+1行目が`missing`と`undefined`を緩い等価で、2行目が厳密等価で比較し、3行目が`typeof missing`の結果を調べて、出力が`true`、`false`、`true`になるようにコードを完成させてください
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/ja/javascript/nullability/5.md
+++ b/ja/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+ほとんどの場合、2つの「値なし」マーカーの*どちら*を受け取ったかは気にしません: 値が存在するかどうかだけを知りたいはずです。
+`null == undefined`は`true`であり、`null`と緩く等しいものは他にないため、`value == null`という比較は**両方**を一度にキャッチする標準的なイディオムです:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+これは`===`よりも`==`が好まれる唯一のケースです: `value === null || value === undefined`と書いてもまったく同じ働きをしますが、より長くなるだけです。
+`0`、`""`、`false`などの値は`null`では*ありません*: それらはたまたまfalsyな実際の値です。
+
+# --instructions--
+
+`value`が`null`または`undefined`のときに`true`を返し、その他の値に対しては`false`を返す関数`isMissing(value)`を書いてください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` は `true` を返すべきです
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` と `isMissing()` は `true` を返すべきです
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` は `false` を返すべきです
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` と `isMissing(false)` は `false` を返すべきです
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` と `isMissing({})` は `false` を返すべきです
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/ja/javascript/nullability/6.md
+++ b/ja/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+`null`または`undefined`のプロパティを読むと、プログラムを停止させるエラーになります:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address`は`undefined`であり、`undefined`にはプロパティがありません。**オプショナルチェーン**演算子`?.`がこれを解決します: 左側の値が`null`または`undefined`の場合、式全体がそこで止まり、スローする代わりに`undefined`と評価されます:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+左側に値がある場合、`?.`は通常の`.`とまったく同じように動作します。いくつでも連鎖できます: `user.address?.street?.name`は、どこかのリンクが欠けている時点で`undefined`を返します。
+
+# --instructions--
+
+オプショナルチェーンを使って、エラーをスローする代わりに両方の行が`undefined`を出力するようにコードを完成させてください
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/ja/javascript/nullability/7.md
+++ b/ja/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+オプショナルチェーンはドットによるプロパティアクセスに限られません。さらに2つの形式があります。
+`?.[]`は左側に値がある場合にのみ、要素または計算されたキーを読みます:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()`は関数が存在する場合にのみ呼び出します。これはオプションのコールバックに便利です:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+どの形式でも、チェックは`?.`の**直前の**値に適用されます: `post?.tags?.[0]`は`post`自体が`null`や`undefined`でも安全です。
+
+# --instructions--
+
+`if`文の代わりにオプショナルチェーンを使って、`post`が存在しない場合、`tags`を持たない場合、または`tags`配列が空の場合に`post.tags`の最初の要素を、それ以外の場合はその要素を返す関数`firstTag(post)`を書いてください。存在しない場合は`undefined`を返してください
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` は `"js"` を返すべきです
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` は `undefined` を返すべきです。`tags`プロパティがないからです
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` は `undefined` を返すべきです
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` と `firstTag(undefined)` はスローせずに `undefined` を返すべきです
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+関数はオプショナルチェーンを使い、`if`を使わないべきです
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/ja/javascript/nullability/8.md
+++ b/ja/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+値が欠けているかもしれないとわかったら、通常はその代わりに**デフォルト**値を用意したくなります。それを行う演算子が2つあり、「欠けている」とみなす基準が異なります。
+`a || b`は`a`が**falsy**なときは常に`b`を返します: `null`と`undefined`だけでなく、`0`、`""`、`false`、`NaN`も対象です。
+**null 合体**演算子`a ?? b`は`a`が`null`または`undefined`のときにのみ`b`を返し、それ以外の値はそのまま保持します:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+`0`、`""`、`false`が保持すべき正当な値である場合は`??`を使い、すべてのfalsyな値を本当に置き換えたい場合は`||`を使ってください。
+
+# --instructions--
+
+1行目が`count`に格納された`0`を保持し、2行目が空の`name`を`"Guest"`に置き換え、3行目が値`false`を保持するようにコードを完成させてください
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/ja/javascript/nullability/9.md
+++ b/ja/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+非常によくあるパターンは「このプロパティがまだ設定されていない場合にのみ埋める」というものです。`??`で書くと名前を繰り返すことになります:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**null 合体代入**演算子`??=`は同じことを1ステップで行います: 左側が現在`null`または`undefined`である場合にのみ右側を代入し、それ以外の値はそのまま残します:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries`は`0`がnullishではないため`0`のままです; `timeout`は存在しなかったので`1000`を受け取ります。同じ考え方は`||`に対する`||=`にも存在し、こちらはすべてのfalsyな値を上書きします。
+
+# --instructions--
+
+次のコードは何を出力しますか？
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/ja/javascript/nullability/_theory.md
+++ b/ja/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScriptには「ここには値がない」ことを表す方法が2つあります。
+`undefined`は値が**一度も提供されていない**ことを意味します。値なしで宣言された変数は`undefined`を持ち、オブジェクトに存在しないプロパティも同様です:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null`は「空であることを、自分はわかっている」と意図的にあなたが代入する値です:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+つまり`undefined`は通常、何かが欠けていることを言語が伝えているものであり、`null`はプログラマーが何かを意図的に空にしていることを示すものです。
+
+---
+
+関数はさらに2つの場面で`undefined`を生み出します。
+宣言されているより**少ない引数**で関数を呼び出すと、欠けている引数は`undefined`になります:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+関数が**`return`なしで**(または`return;`のみで)終わると、呼び出しの結果は`undefined`になります:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+`null`を明示的に渡すことは引数を省略することと同じではないことに注意してください: `greet(null)`は`null`を出力します。`null`は関数に渡された実際の値だからです。
+
+---
+
+`typeof`演算子は値の型を文字列として返します。`undefined`に対しては期待どおり`"undefined"`と答えます:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+しかし`null`に対しては`"object"`と答えます。これはJavaScriptの最初のバージョンからのバグで、あまりに多くのコードがそれに依存しているため修正されることはありませんでした:
+```javascript
+console.log(typeof null);
+// prints object
+```
+したがって`typeof`は`undefined`を検出する確実な方法ですが、`null`の検出には使えません。`null`を調べるには、直接比較します: `value === null`。
+
+---
+
+`null`と`undefined`は互いにどのように比較されるのでしょうか？ それは演算子によります。
+**緩い**等価演算子`==`は両者を同じものとして扱い、`0`、`""`、`false`を含む他のどの値とも異なるものとみなします:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**厳密**等価演算子`===`は型も比較しますが、`null`と`undefined`は型が異なります:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+ほとんどの場合、2つの「値なし」マーカーの*どちら*を受け取ったかは気にしません: 値が存在するかどうかだけを知りたいはずです。
+`null == undefined`は`true`であり、`null`と緩く等しいものは他にないため、`value == null`という比較は**両方**を一度にキャッチする標準的なイディオムです:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+これは`===`よりも`==`が好まれる唯一のケースです: `value === null || value === undefined`と書いてもまったく同じ働きをしますが、より長くなるだけです。
+`0`、`""`、`false`などの値は`null`では*ありません*: それらはたまたまfalsyな実際の値です。
+
+---
+
+`null`または`undefined`のプロパティを読むと、プログラムを停止させるエラーになります:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address`は`undefined`であり、`undefined`にはプロパティがありません。**オプショナルチェーン**演算子`?.`がこれを解決します: 左側の値が`null`または`undefined`の場合、式全体がそこで止まり、スローする代わりに`undefined`と評価されます:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+左側に値がある場合、`?.`は通常の`.`とまったく同じように動作します。いくつでも連鎖できます: `user.address?.street?.name`は、どこかのリンクが欠けている時点で`undefined`を返します。
+
+---
+
+オプショナルチェーンはドットによるプロパティアクセスに限られません。さらに2つの形式があります。
+`?.[]`は左側に値がある場合にのみ、要素または計算されたキーを読みます:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()`は関数が存在する場合にのみ呼び出します。これはオプションのコールバックに便利です:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+どの形式でも、チェックは`?.`の**直前の**値に適用されます: `post?.tags?.[0]`は`post`自体が`null`や`undefined`でも安全です。
+
+---
+
+値が欠けているかもしれないとわかったら、通常はその代わりに**デフォルト**値を用意したくなります。それを行う演算子が2つあり、「欠けている」とみなす基準が異なります。
+`a || b`は`a`が**falsy**なときは常に`b`を返します: `null`と`undefined`だけでなく、`0`、`""`、`false`、`NaN`も対象です。
+**null 合体**演算子`a ?? b`は`a`が`null`または`undefined`のときにのみ`b`を返し、それ以外の値はそのまま保持します:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+`0`、`""`、`false`が保持すべき正当な値である場合は`??`を使い、すべてのfalsyな値を本当に置き換えたい場合は`||`を使ってください。
+
+---
+
+非常によくあるパターンは「このプロパティがまだ設定されていない場合にのみ埋める」というものです。`??`で書くと名前を繰り返すことになります:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**null 合体代入**演算子`??=`は同じことを1ステップで行います: 左側が現在`null`または`undefined`である場合にのみ右側を代入し、それ以外の値はそのまま残します:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries`は`0`がnullishではないため`0`のままです; `timeout`は存在しなかったので`1000`を受け取ります。同じ考え方は`||`に対する`||=`にも存在し、こちらはすべてのfalsyな値を上書きします。
+
+---
+
+**デフォルト引数**は、呼び出し側が値を提供しなかった場合に引数へ値を与えます。そのルールは正確です: デフォルトが使われるのは引数が`undefined`のときだけです。これは引数の省略も含みます。`null`を渡してもデフォルトは発動**しません**。`null`は値だからです:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+デフォルト引数は`undefined`のルールに従いますが、`??`は`null`と`undefined`の両方をカバーします: 関数がどのように呼ばれるかに合わせて選んでください。
+
+---
+
+オプショナルチェーンと`== null`によるガードはうまく連携します: チェーンはネストした値をスローせずに読み、ガードは結果が欠けている場合の対処を決めます:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+最後の`return`の中ではプレーンな`.`が安全です。ガードがすべてのリンクの存在をすでに証明しているからです。
+
+---
+
+多くの組み込みメソッドは「何も見つからなかった」ことを`undefined`を返すことで報告します。配列メソッド`find(callback)`が典型的な例です: コールバックが`true`になる最初の要素を返し、一致する要素がない場合は`undefined`を返します:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+ここで`found.price`を読むとスローしてしまうため、`?.`と`??`は`find`の自然な相棒です:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null`と`undefined`は、`JSON.stringify()`でオブジェクトをJSONに変換するときに異なる動作をします。
+JSONには`null`という値はありますが`undefined`はありません。そのため、値が`undefined`のプロパティは単に**省かれ**、`null`のプロパティは保持されます:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+配列の中では位置を消すことができないため、そこでは`undefined`は`null`になります:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+`obj.key === undefined`のチェックでは、2つの場面を区別できません: プロパティが存在しないのか、存在するが値として`undefined`を持っているのかです。
+`Object.hasOwn(obj, key)`は最初の疑問にのみ答えます: オブジェクトが`key`という名前の**自身の**プロパティを持っていれば、その値が何であれ`true`を返します:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+「自身の」とは、オブジェクト自体に宣言されたことを意味します: `toString`のような継承されたメンバーはすべてのオブジェクトで利用できますが、`Object.hasOwn(config, "toString")`は`false`です。

--- a/ko/javascript/data.json
+++ b/ko/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "화살표 함수",
         "description": "짧은 익명 함수를 작성하는 방법을 배웁니다"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "널 가능성",
+        "description": "null 또는 undefined일 수 있는 값을 다루는 방법을 배웁니다"
     }
 }

--- a/ko/javascript/nullability/1.md
+++ b/ko/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript에는 "여기에 값이 없다"고 말하는 두 가지 서로 다른 방식이 있습니다.
+`undefined`는 값이 **한 번도 제공되지 않았다**는 뜻입니다. 값 없이 선언된 변수는 `undefined`를 가지며, 객체에 존재하지 않는 프로퍼티도 마찬가지입니다:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null`은 "비어 있고, 그것을 알고 있다"고 말하기 위해 **여러분이** 의도적으로 할당하는 값입니다:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+즉, `undefined`는 보통 무언가 빠져 있다고 언어가 알려주는 것이고, `null`은 프로그래머가 무언가를 의도적으로 비워 두었다고 선언하는 것입니다.
+
+# --instructions--
+
+`city`가 값 없이 선언되고 `owner`가 명시적으로 `null`로 설정되도록 코드를 완성하세요
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/ko/javascript/nullability/10.md
+++ b/ko/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+**기본 매개변수**는 호출자가 값을 제공하지 않을 때 매개변수에 값을 줍니다. 규칙은 정확합니다: 기본값은 인자가 `undefined`일 때만 사용되며, 인자를 생략하는 것도 여기에 포함됩니다. `null`을 전달하면 `null`은 값이므로 기본값이 트리거되지 **않습니다**:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+기본 매개변수는 `undefined` 규칙을 따르는 반면, `??`는 `null`과 `undefined`를 모두 다룹니다: 함수가 호출되는 방식에 맞는 것을 선택하세요.
+
+# --instructions--
+
+`width`에 기본 매개변수를 사용하여, `width` 길이에 도달할 때까지 필요한 만큼의 `"."` 문자를 `text` 뒤에 붙여 반환하는 함수 `pad(text, width = 5)`를 작성하세요; `text`가 이미 `width`자 이상이면 그대로 반환합니다
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)`는 `"ab.."`를 반환해야 합니다
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")`는 기본 너비 `5`를 사용해 `"ab..."`를 반환해야 합니다
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)`도 기본 너비를 사용해야 합니다
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)`은 `"ab"`를 반환해야 합니다. `null`은 기본값을 트리거하지 않고 `0`으로 변환되기 때문입니다.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")`는 `"abcdef"`를 그대로 반환해야 합니다
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width`는 기본 매개변수로 선언되어야 합니다
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/ko/javascript/nullability/11.md
+++ b/ko/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+옵셔널 체이닝과 `== null` 검사는 잘 어울립니다: 체인은 에러를 던지지 않고 중첩된 값을 읽고, 검사는 결과가 없을 때 무엇을 할지 결정합니다:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+마지막 `return` 안에서는 일반 `.`이 안전합니다. 검사가 이미 모든 연결이 존재한다는 것을 증명했기 때문입니다.
+
+# --instructions--
+
+사용자에게 도시가 없으면 `"unknown"`을, 있으면 그 도시를 반환하는 `cityOf`를 정의하도록 줄을 정렬한 다음, 주소가 없는 사용자와 `Rome`에 사는 사용자에 대한 결과를 출력하세요. 함수를 먼저 정의하세요
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/ko/javascript/nullability/12.md
+++ b/ko/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+많은 내장 메서드는 "찾지 못했음"을 `undefined`를 반환해서 알립니다. 배열 메서드 `find(callback)`이 대표적인 예입니다. 콜백이 `true`인 첫 번째 요소를 반환하고, 일치하는 요소가 없으면 `undefined`를 반환합니다:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+여기서 `found.price`를 읽으면 에러가 발생하므로, `?.`와 `??`는 `find`와 자연스럽게 함께 쓰입니다:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+`find`를 사용해, `products` 중 `name`이 일치하는 상품의 `price`를 반환하고 그런 상품이 없으면 `null`을 반환하는 함수 `priceOf(products, name)`를 작성하세요
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")`는 `7`을 반환해야 합니다
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")`는 `null`을 반환해야 합니다
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")`은 `null`을 반환해야 합니다
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")`는 `null`이 아니라 `0`을 반환해야 합니다
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+함수는 `find`를 사용해야 합니다
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/ko/javascript/nullability/13.md
+++ b/ko/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null`과 `undefined`는 `JSON.stringify()`로 객체를 JSON으로 변환할 때 서로 다르게 동작합니다.
+JSON에는 `null` 값은 있지만 `undefined`는 없습니다. 그래서 값이 `undefined`인 프로퍼티는 그냥 **빠지고**, `null`인 프로퍼티는 유지됩니다:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+배열 안에서는 자리를 없앨 수 없기 때문에, 거기서는 `undefined`가 `null`이 됩니다:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+다음 코드는 무엇을 출력하나요?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/ko/javascript/nullability/14.md
+++ b/ko/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+`obj.key === undefined` 검사는 두 가지 상황을 구분하지 못합니다. 프로퍼티가 존재하지 않는 경우와, 존재하지만 값이 `undefined`인 경우입니다.
+`Object.hasOwn(obj, key)`는 첫 번째 질문에만 답합니다. 값과 상관없이 객체가 `key`라는 **자기 자신의** 프로퍼티를 가지고 있으면 `true`를 반환합니다:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"자기 자신의"란 객체 자체에 선언되었다는 뜻입니다. `toString` 같은 상속된 멤버는 모든 객체에서 사용할 수 있지만 `Object.hasOwn(config, "toString")`은 `false`입니다.
+
+# --instructions--
+
+`Object.hasOwn`을 사용해, `obj`에 `key`라는 자기 자신의 프로퍼티가 없으면 `"missing"`을, 프로퍼티는 있지만 값이 `null`이거나 `undefined`이면 `"empty"`를, 그 외의 모든 경우에는 `"set"`을 반환하는 함수 `describeKey(obj, key)`를 작성하세요
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")`는 `"set"`을 반환해야 합니다
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")`와 `describeKey({ a: "" }, "a")`는 `"set"`을 반환해야 합니다
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")`와 `describeKey({ a: null }, "a")`는 `"empty"`를 반환해야 합니다
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")`는 `"missing"`을 반환해야 합니다
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`toString`은 상속된 것이지 자기 자신의 프로퍼티가 아니므로 `describeKey({}, "toString")`은 `"missing"`을 반환해야 합니다
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+함수는 `Object.hasOwn`을 사용해야 합니다
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/ko/javascript/nullability/15.md
+++ b/ko/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+작업의 선택적 `onDone` 콜백을 호출하고 그 `name` 또는 `"untitled"`를 반환하는 `finish`를 정의하도록 줄을 정렬한 다음, `done`을 출력하는 콜백을 가진 `build`라는 이름의 작업과 빈 작업에 대한 결과를 출력하세요. 함수를 먼저 정의하세요
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/ko/javascript/nullability/16.md
+++ b/ko/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+`path`가 `"address.city"`처럼 점으로 구분된 프로퍼티 이름 문자열인 함수 `pick(obj, path, fallback)`을 작성하세요. 경로를 따라가서 찾은 중첩된 값을 반환하고, 중간 단계나 최종 값이 `null` 또는 `undefined`이면 `fallback`을 반환해야 합니다. `0`, `""`, `false` 같은 값은 그대로 반환되어야 합니다
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")`은 `"Rome"`을 반환해야 합니다
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")`은 `"unknown"`을 반환해야 합니다
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)`은 에러 없이 `0`을 반환해야 합니다
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)`는 `0`을, `pick({ name: "" }, "name", "anon")`은 `""`를 반환해야 합니다
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)`는 `false`를 반환해야 합니다
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")`과 `pick({ x: undefined }, "x", "none")`은 `"none"`을 반환해야 합니다
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/ko/javascript/nullability/2.md
+++ b/ko/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+함수는 두 가지 상황이 더 `undefined`를 만들어 냅니다.
+함수를 선언된 것보다 **적은 수의 인자**로 호출하면, 빠진 매개변수는 `undefined`를 가집니다:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+함수가 **`return` 없이** (또는 `return;`만으로) 끝나면, 호출 결과는 `undefined`입니다:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+`null`을 명시적으로 전달하는 것은 인자를 생략하는 것과 같지 않다는 점에 주의하세요: `greet(null)`은 `null`을 출력하는데, `null`은 함수에 전달된 실제 값이기 때문입니다.
+
+# --instructions--
+
+`name`이 `undefined`일 때 (예를 들어 인자가 생략된 경우) `"Guest"`를 반환하고, `null`을 포함한 그 외의 모든 경우에는 `name`을 그대로 반환하는 함수 `nameOrGuest(name)`을 작성하세요
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")`는 `"Ana"`를 반환해야 합니다
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()`는 `"Guest"`를 반환해야 합니다. 빠진 인자가 `undefined`이기 때문입니다.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)`는 `"Guest"`를 반환해야 합니다
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)`은 `null`을 반환해야 합니다. `null`은 의도적으로 전달된 값이기 때문입니다.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")`는 `""`를 반환해야 합니다
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/ko/javascript/nullability/3.md
+++ b/ko/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`typeof` 연산자는 값의 타입을 문자열로 반환합니다. `undefined`에 대해서는 예상대로 `"undefined"`라고 답합니다:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+그러나 `null`에 대해서는 `"object"`라고 답합니다. 이것은 너무 많은 코드가 이 동작에 의존하기 때문에 한 번도 수정되지 않은, JavaScript 첫 버전의 버그입니다:
+```javascript
+console.log(typeof null);
+// prints object
+```
+따라서 `typeof`는 `undefined`를 감지하는 신뢰할 수 있는 방법이지만, `null`은 그렇지 않습니다. `null`을 확인하려면 직접 비교하세요: `value === null`.
+
+# --instructions--
+
+이 코드는 무엇을 출력할까요?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/ko/javascript/nullability/4.md
+++ b/ko/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+`null`과 `undefined`는 서로 비교하면 어떻게 될까요? 연산자에 따라 다릅니다.
+**느슨한** 동등 비교 `==`는 이 둘을 같은 것으로 취급하고, `0`, `""`, `false`를 포함한 다른 모든 값과는 다른 것으로 봅니다:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**엄격한** 동등 비교 `===`는 타입까지 비교하는데, `null`과 `undefined`는 타입이 다릅니다:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+첫 번째 줄은 `missing`과 `undefined`를 느슨한 동등 비교로, 두 번째 줄은 엄격한 동등 비교로 비교하고, 세 번째 줄은 `typeof missing`의 결과를 검사하여 출력이 `true`, `false`, `true`가 되도록 코드를 완성하세요
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/ko/javascript/nullability/5.md
+++ b/ko/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+대부분의 경우 두 "값 없음" 표시 중 *어느 쪽*을 받았는지는 중요하지 않습니다. 그저 값이 있는지 없는지 알고 싶을 뿐입니다.
+`null == undefined`는 `true`이고 `null`과 느슨하게 같은 다른 값은 없으므로, `value == null` 비교는 **둘**을 한 번에 잡아내는 표준 관용구입니다:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+이것은 `==`가 `===`보다 선호되는 유일한 경우입니다: `value === null || value === undefined`라고 써도 정확히 같은 일을 하지만 더 길어질 뿐입니다.
+`0`, `""`, `false` 같은 값은 `null`이 *아닙니다*: 이것들은 우연히 falsy한 실제 값들입니다.
+
+# --instructions--
+
+`value`가 `null` 또는 `undefined`일 때 `true`를 반환하고, 다른 모든 값에 대해서는 `false`를 반환하는 함수 `isMissing(value)`를 작성하세요
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)`은 `true`를 반환해야 합니다
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)`와 `isMissing()`은 `true`를 반환해야 합니다
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)`은 `false`를 반환해야 합니다
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")`과 `isMissing(false)`는 `false`를 반환해야 합니다
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])`과 `isMissing({})`는 `false`를 반환해야 합니다
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/ko/javascript/nullability/6.md
+++ b/ko/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+`null`이나 `undefined`의 프로퍼티를 읽으려고 하면 프로그램을 멈추는 에러가 발생합니다:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address`는 `undefined`이고, `undefined`는 프로퍼티가 없습니다. **옵셔널 체이닝** 연산자 `?.`가 이것을 해결합니다: 왼쪽의 값이 `null`이나 `undefined`이면 전체 표현식이 중단되고, 에러를 던지는 대신 `undefined`로 평가됩니다:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+왼쪽에 실제 값이 있으면 `?.`는 일반 `.`과 똑같이 동작합니다. 여러 개를 연결할 수도 있습니다: `user.address?.street?.name`은 체인 중 어느 하나라도 빠져 있으면 `undefined`를 반환합니다.
+
+# --instructions--
+
+옵셔널 체이닝을 사용해 에러를 던지는 대신 두 줄 모두 `undefined`를 출력하도록 코드를 완성하세요
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/ko/javascript/nullability/7.md
+++ b/ko/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+옵셔널 체이닝은 점 프로퍼티에만 국한되지 않습니다. 두 가지 형태가 더 있습니다.
+`?.[]`는 왼쪽에 값이 있을 때만 요소나 계산된 키를 읽습니다:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()`는 함수가 존재할 때만 호출하며, 선택적인 콜백에 유용합니다:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+어떤 형태에서든 검사는 `?.` **바로 앞의** 값에 적용됩니다: `post?.tags?.[0]`은 `post` 자체가 `null`이나 `undefined`일 때도 안전합니다.
+
+# --instructions--
+
+`if` 문 대신 옵셔널 체이닝을 사용하여, `post.tags`의 첫 번째 요소를 반환하고 `post`가 없거나 `tags`가 없거나 `tags` 배열이 비어 있으면 `undefined`를 반환하는 함수 `firstTag(post)`를 작성하세요
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })`는 `"js"`를 반환해야 합니다
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })`는 `undefined`를 반환해야 합니다. `tags` 프로퍼티가 없기 때문입니다.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })`는 `undefined`를 반환해야 합니다
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)`과 `firstTag(undefined)`는 에러 없이 `undefined`를 반환해야 합니다
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+함수는 옵셔널 체이닝을 사용해야 하며 `if`를 사용하면 안 됩니다
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/ko/javascript/nullability/8.md
+++ b/ko/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+값이 없을 수 있다는 것을 알고 나면 보통 그 자리에 **기본값**을 넣고 싶어집니다. 두 연산자가 이 일을 하며, 무엇을 "없음"으로 간주하는지가 다릅니다.
+`a || b`는 `a`가 **falsy**일 때마다 `b`를 반환합니다: `null`과 `undefined`뿐만 아니라 `0`, `""`, `false`, `NaN`도 마찬가지입니다.
+**널 병합** 연산자 `a ?? b`는 `a`가 `null`이나 `undefined`일 때만 `b`를 반환하고, 다른 모든 값은 그대로 유지합니다:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+`0`, `""`, `false`가 유지해야 할 정당한 값일 때는 `??`를, 정말로 모든 falsy 값을 바꾸고 싶을 때는 `||`를 사용하세요.
+
+# --instructions--
+
+첫 번째 줄은 `count`에 저장된 `0`을 유지하고, 두 번째 줄은 빈 `name`을 `"Guest"`로 바꾸며, 세 번째 줄은 값 `false`를 유지하도록 코드를 완성하세요
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/ko/javascript/nullability/9.md
+++ b/ko/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+아주 흔한 패턴은 "이 프로퍼티가 아직 설정되지 않은 경우에만 채우기"입니다. `??`로 쓰면 이름을 반복하게 됩니다:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**널 병합 할당** 연산자 `??=`는 이것을 한 단계로 처리합니다: 왼쪽이 현재 `null`이나 `undefined`일 때만 오른쪽을 할당하고, 다른 값은 그대로 둡니다:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries`는 `0`이 nullish가 아니므로 `0`으로 유지되고, `timeout`은 존재하지 않았으므로 `1000`을 받습니다. 같은 아이디어가 `||`에는 `||=`로 존재하며, 이것은 모든 falsy 값을 덮어씁니다.
+
+# --instructions--
+
+이 코드는 무엇을 출력할까요?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/ko/javascript/nullability/_theory.md
+++ b/ko/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript에는 "여기에 값이 없다"고 말하는 두 가지 서로 다른 방식이 있습니다.
+`undefined`는 값이 **한 번도 제공되지 않았다**는 뜻입니다. 값 없이 선언된 변수는 `undefined`를 가지며, 객체에 존재하지 않는 프로퍼티도 마찬가지입니다:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null`은 "비어 있고, 그것을 알고 있다"고 말하기 위해 **여러분이** 의도적으로 할당하는 값입니다:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+즉, `undefined`는 보통 무언가 빠져 있다고 언어가 알려주는 것이고, `null`은 프로그래머가 무언가를 의도적으로 비워 두었다고 선언하는 것입니다.
+
+---
+
+함수는 두 가지 상황이 더 `undefined`를 만들어 냅니다.
+함수를 선언된 것보다 **적은 수의 인자**로 호출하면, 빠진 매개변수는 `undefined`를 가집니다:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+함수가 **`return` 없이** (또는 `return;`만으로) 끝나면, 호출 결과는 `undefined`입니다:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+`null`을 명시적으로 전달하는 것은 인자를 생략하는 것과 같지 않다는 점에 주의하세요: `greet(null)`은 `null`을 출력하는데, `null`은 함수에 전달된 실제 값이기 때문입니다.
+
+---
+
+`typeof` 연산자는 값의 타입을 문자열로 반환합니다. `undefined`에 대해서는 예상대로 `"undefined"`라고 답합니다:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+그러나 `null`에 대해서는 `"object"`라고 답합니다. 이것은 너무 많은 코드가 이 동작에 의존하기 때문에 한 번도 수정되지 않은, JavaScript 첫 버전의 버그입니다:
+```javascript
+console.log(typeof null);
+// prints object
+```
+따라서 `typeof`는 `undefined`를 감지하는 신뢰할 수 있는 방법이지만, `null`은 그렇지 않습니다. `null`을 확인하려면 직접 비교하세요: `value === null`.
+
+---
+
+`null`과 `undefined`는 서로 비교하면 어떻게 될까요? 연산자에 따라 다릅니다.
+**느슨한** 동등 비교 `==`는 이 둘을 같은 것으로 취급하고, `0`, `""`, `false`를 포함한 다른 모든 값과는 다른 것으로 봅니다:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**엄격한** 동등 비교 `===`는 타입까지 비교하는데, `null`과 `undefined`는 타입이 다릅니다:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+대부분의 경우 두 "값 없음" 표시 중 *어느 쪽*을 받았는지는 중요하지 않습니다. 그저 값이 있는지 없는지 알고 싶을 뿐입니다.
+`null == undefined`는 `true`이고 `null`과 느슨하게 같은 다른 값은 없으므로, `value == null` 비교는 **둘**을 한 번에 잡아내는 표준 관용구입니다:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+이것은 `==`가 `===`보다 선호되는 유일한 경우입니다: `value === null || value === undefined`라고 써도 정확히 같은 일을 하지만 더 길어질 뿐입니다.
+`0`, `""`, `false` 같은 값은 `null`이 *아닙니다*: 이것들은 우연히 falsy한 실제 값들입니다.
+
+---
+
+`null`이나 `undefined`의 프로퍼티를 읽으려고 하면 프로그램을 멈추는 에러가 발생합니다:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address`는 `undefined`이고, `undefined`는 프로퍼티가 없습니다. **옵셔널 체이닝** 연산자 `?.`가 이것을 해결합니다: 왼쪽의 값이 `null`이나 `undefined`이면 전체 표현식이 중단되고, 에러를 던지는 대신 `undefined`로 평가됩니다:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+왼쪽에 실제 값이 있으면 `?.`는 일반 `.`과 똑같이 동작합니다. 여러 개를 연결할 수도 있습니다: `user.address?.street?.name`은 체인 중 어느 하나라도 빠져 있으면 `undefined`를 반환합니다.
+
+---
+
+옵셔널 체이닝은 점 프로퍼티에만 국한되지 않습니다. 두 가지 형태가 더 있습니다.
+`?.[]`는 왼쪽에 값이 있을 때만 요소나 계산된 키를 읽습니다:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()`는 함수가 존재할 때만 호출하며, 선택적인 콜백에 유용합니다:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+어떤 형태에서든 검사는 `?.` **바로 앞의** 값에 적용됩니다: `post?.tags?.[0]`은 `post` 자체가 `null`이나 `undefined`일 때도 안전합니다.
+
+---
+
+값이 없을 수 있다는 것을 알고 나면 보통 그 자리에 **기본값**을 넣고 싶어집니다. 두 연산자가 이 일을 하며, 무엇을 "없음"으로 간주하는지가 다릅니다.
+`a || b`는 `a`가 **falsy**일 때마다 `b`를 반환합니다: `null`과 `undefined`뿐만 아니라 `0`, `""`, `false`, `NaN`도 마찬가지입니다.
+**널 병합** 연산자 `a ?? b`는 `a`가 `null`이나 `undefined`일 때만 `b`를 반환하고, 다른 모든 값은 그대로 유지합니다:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+`0`, `""`, `false`가 유지해야 할 정당한 값일 때는 `??`를, 정말로 모든 falsy 값을 바꾸고 싶을 때는 `||`를 사용하세요.
+
+---
+
+아주 흔한 패턴은 "이 프로퍼티가 아직 설정되지 않은 경우에만 채우기"입니다. `??`로 쓰면 이름을 반복하게 됩니다:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**널 병합 할당** 연산자 `??=`는 이것을 한 단계로 처리합니다: 왼쪽이 현재 `null`이나 `undefined`일 때만 오른쪽을 할당하고, 다른 값은 그대로 둡니다:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries`는 `0`이 nullish가 아니므로 `0`으로 유지되고, `timeout`은 존재하지 않았으므로 `1000`을 받습니다. 같은 아이디어가 `||`에는 `||=`로 존재하며, 이것은 모든 falsy 값을 덮어씁니다.
+
+---
+
+**기본 매개변수**는 호출자가 값을 제공하지 않을 때 매개변수에 값을 줍니다. 규칙은 정확합니다: 기본값은 인자가 `undefined`일 때만 사용되며, 인자를 생략하는 것도 여기에 포함됩니다. `null`을 전달하면 `null`은 값이므로 기본값이 트리거되지 **않습니다**:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+기본 매개변수는 `undefined` 규칙을 따르는 반면, `??`는 `null`과 `undefined`를 모두 다룹니다: 함수가 호출되는 방식에 맞는 것을 선택하세요.
+
+---
+
+옵셔널 체이닝과 `== null` 검사는 잘 어울립니다: 체인은 에러를 던지지 않고 중첩된 값을 읽고, 검사는 결과가 없을 때 무엇을 할지 결정합니다:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+마지막 `return` 안에서는 일반 `.`이 안전합니다. 검사가 이미 모든 연결이 존재한다는 것을 증명했기 때문입니다.
+
+---
+
+많은 내장 메서드는 "찾지 못했음"을 `undefined`를 반환해서 알립니다. 배열 메서드 `find(callback)`이 대표적인 예입니다. 콜백이 `true`인 첫 번째 요소를 반환하고, 일치하는 요소가 없으면 `undefined`를 반환합니다:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+여기서 `found.price`를 읽으면 에러가 발생하므로, `?.`와 `??`는 `find`와 자연스럽게 함께 쓰입니다:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null`과 `undefined`는 `JSON.stringify()`로 객체를 JSON으로 변환할 때 서로 다르게 동작합니다.
+JSON에는 `null` 값은 있지만 `undefined`는 없습니다. 그래서 값이 `undefined`인 프로퍼티는 그냥 **빠지고**, `null`인 프로퍼티는 유지됩니다:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+배열 안에서는 자리를 없앨 수 없기 때문에, 거기서는 `undefined`가 `null`이 됩니다:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+`obj.key === undefined` 검사는 두 가지 상황을 구분하지 못합니다. 프로퍼티가 존재하지 않는 경우와, 존재하지만 값이 `undefined`인 경우입니다.
+`Object.hasOwn(obj, key)`는 첫 번째 질문에만 답합니다. 값과 상관없이 객체가 `key`라는 **자기 자신의** 프로퍼티를 가지고 있으면 `true`를 반환합니다:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"자기 자신의"란 객체 자체에 선언되었다는 뜻입니다. `toString` 같은 상속된 멤버는 모든 객체에서 사용할 수 있지만 `Object.hasOwn(config, "toString")`은 `false`입니다.

--- a/pl/javascript/data.json
+++ b/pl/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Funkcje strzałkowe",
         "description": "Naucz się pisać krótkie anonimowe funkcje"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullowalność",
+        "description": "Naucz się obsługiwać wartości, które mogą być null lub undefined"
     }
 }

--- a/pl/javascript/nullability/1.md
+++ b/pl/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript ma dwa różne sposoby na powiedzenie "nie ma tu żadnej wartości".
+`undefined` oznacza, że wartość **nigdy nie została dostarczona**. Zmienna zadeklarowana bez wartości przyjmuje `undefined`, i tak samo właściwość, która nie istnieje w obiekcie:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` to wartość, którą **Ty** przypisujesz celowo, aby powiedzieć "pusto, i wiem o tym":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Zatem `undefined` to zwykle język informujący Cię, że czegoś brakuje, podczas gdy `null` to programista stwierdzający, że coś jest celowo puste.
+
+# --instructions--
+
+Uzupełnij kod tak, aby `city` było zadeklarowane bez wartości, a `owner` był jawnie ustawiony na `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/pl/javascript/nullability/10.md
+++ b/pl/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+**Parametr domyślny** nadaje parametrowi wartość, gdy wywołujący jej nie podaje. Zasada jest precyzyjna: wartość domyślna jest używana tylko wtedy, gdy argument to `undefined`, co obejmuje jego pominięcie. Przekazanie `null` **nie** uruchamia wartości domyślnej, ponieważ `null` to wartość:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Parametry domyślne stosują regułę `undefined`, podczas gdy `??` obejmuje i `null`, i `undefined`: wybierz to, które pasuje do sposobu wywoływania Twojej funkcji.
+
+# --instructions--
+
+Napisz funkcję `pad(text, width = 5)`, która zwraca `text` z dołączoną liczbą znaków `"."` potrzebną, aby osiągnąć `width` znaków, używając parametru domyślnego dla `width`; gdy `text` ma już `width` znaków lub więcej, zwróć go bez zmian
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` musi zwracać `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` musi zwracać `"ab..."`, używając domyślnej szerokości `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` również musi używać domyślnej szerokości.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` musi zwracać `"ab"`, ponieważ `null` nie uruchamia wartości domyślnej i jest konwertowane na `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` musi zwracać `"abcdef"` bez zmian.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` musi być zadeklarowane jako parametr domyślny.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/pl/javascript/nullability/11.md
+++ b/pl/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Opcjonalne łańcuchowanie i zabezpieczenie `== null` dobrze ze sobą współpracują: łańcuch odczytuje zagnieżdżoną wartość bez zgłaszania błędu, a zabezpieczenie decyduje, co zrobić, gdy wynik jest brakujący:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+W ostatnim `return` zwykła kropka `.` jest bezpieczna, ponieważ zabezpieczenie już udowodniło, że każde ogniwo istnieje.
+
+# --instructions--
+
+Ułóż linie tak, aby zdefiniować `cityOf`, która zwraca `"unknown"`, gdy użytkownik nie ma miasta, a w przeciwnym razie miasto, a następnie wypisz wynik dla użytkownika bez adresu i dla użytkownika mieszkającego w `Rome`. Najpierw zdefiniuj funkcję
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/pl/javascript/nullability/12.md
+++ b/pl/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Wiele wbudowanych metod zgłasza "niczego nie znaleziono", zwracając `undefined`. Metoda tablic `find(callback)` to typowy przykład: zwraca pierwszy element, dla którego callback daje `true`, albo `undefined`, gdy żaden element nie pasuje:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Odczytanie tutaj `found.price` zgłosiłoby błąd, więc `?.` i `??` to naturalni towarzysze `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Napisz funkcję `priceOf(products, name)`, która zwraca `price` produktu z `products`, którego `name` pasuje, albo `null`, gdy nie ma takiego produktu, używając `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` musi zwracać `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` musi zwracać `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` musi zwracać `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` musi zwracać `0`, a nie `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+Funkcja musi używać `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/pl/javascript/nullability/13.md
+++ b/pl/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` i `undefined` zachowują się różnie, gdy obiekt jest konwertowany do JSON za pomocą `JSON.stringify()`.
+JSON ma wartość `null`, ale nie ma `undefined`, więc właściwość o wartości `undefined` jest po prostu **pomijana**, a właściwość `null` jest zachowywana:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Wewnątrz tablic pozycje nie mogą zniknąć, więc tam `undefined` staje się `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+Co wypisze ten kod?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/pl/javascript/nullability/14.md
+++ b/pl/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Sprawdzenie `obj.key === undefined` nie potrafi odróżnić dwóch sytuacji: właściwość nie istnieje albo istnieje i przechowuje wartość `undefined`.
+`Object.hasOwn(obj, key)` odpowiada tylko na pierwsze pytanie: zwraca `true`, gdy obiekt ma **własną** właściwość o nazwie `key`, niezależnie od jej wartości:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Własna" oznacza zadeklarowaną na samym obiekcie: dziedziczone składowe, takie jak `toString`, są dostępne na każdym obiekcie, ale `Object.hasOwn(config, "toString")` daje `false`.
+
+# --instructions--
+
+Napisz funkcję `describeKey(obj, key)`, która zwraca `"missing"`, gdy `obj` nie ma własnej właściwości `key`, `"empty"`, gdy właściwość istnieje, ale przechowuje `null` lub `undefined`, oraz `"set"` w każdym innym przypadku, używając `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` musi zwracać `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` i `describeKey({ a: "" }, "a")` muszą zwracać `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` i `describeKey({ a: null }, "a")` muszą zwracać `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` musi zwracać `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` musi zwracać `"missing"`, ponieważ `toString` jest dziedziczone, a nie własne.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+Funkcja musi używać `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/pl/javascript/nullability/15.md
+++ b/pl/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Ułóż linie tak, aby zdefiniować `finish`, która wywołuje opcjonalny callback `onDone` zadania i zwraca jego `name` albo `"untitled"`, a następnie wypisz wynik dla zadania o nazwie `build` z callbackiem wypisującym `done` oraz dla pustego zadania. Najpierw zdefiniuj funkcję
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/pl/javascript/nullability/16.md
+++ b/pl/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Napisz funkcję `pick(obj, path, fallback)`, gdzie `path` to ciąg znaków z nazwami właściwości rozdzielonymi kropkami, na przykład `"address.city"`; musi ona zwracać zagnieżdżoną wartość znalezioną przez przejście wzdłuż ścieżki, albo `fallback`, gdy dowolny krok lub wartość końcowa to `null` lub `undefined`; wartości takie jak `0`, `""` i `false` muszą być zwracane bez zmian
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` musi zwracać `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` musi zwracać `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` musi zwracać `0` bez zgłaszania błędu.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` musi zwracać `0`, a `pick({ name: "" }, "name", "anon")` musi zwracać `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` musi zwracać `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` i `pick({ x: undefined }, "x", "none")` muszą zwracać `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/pl/javascript/nullability/2.md
+++ b/pl/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Funkcje dają `undefined` jeszcze w dwóch sytuacjach.
+Gdy wywołasz funkcję z **mniejszą liczbą argumentów**, niż deklaruje, brakujące parametry przyjmują `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Gdy funkcja kończy działanie **bez `return`** (lub z samym `return;`), jej wywołanie daje `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Zauważ, że jawne przekazanie `null` to nie to samo, co pominięcie argumentu: `greet(null)` wypisuje `null`, ponieważ `null` to prawdziwa wartość przekazana do funkcji.
+
+# --instructions--
+
+Napisz funkcję `nameOrGuest(name)`, która zwraca `"Guest"`, gdy `name` to `undefined` (na przykład dlatego, że argument został pominięty), a w każdym innym przypadku, w tym dla `null`, zwraca `name` bez zmian
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` musi zwracać `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` musi zwracać `"Guest"`, ponieważ brakujący argument to `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` musi zwracać `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` musi zwracać `null`, ponieważ `null` to wartość przekazana celowo.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` musi zwracać `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/pl/javascript/nullability/3.md
+++ b/pl/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Operator `typeof` zwraca typ wartości w postaci ciągu znaków. Dla `undefined` odpowiada `"undefined"`, zgodnie z oczekiwaniami:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Dla `null` odpowiada jednak `"object"`. To błąd z samej pierwszej wersji JavaScriptu, którego nigdy nie naprawiono, ponieważ zbyt dużo kodu od niego zależy:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Zatem `typeof` to niezawodny sposób wykrycia `undefined`, ale już nie `null`. Aby sprawdzić `null`, porównaj z nią bezpośrednio: `value === null`.
+
+# --instructions--
+
+Co wypisze ten kod?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/pl/javascript/nullability/4.md
+++ b/pl/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Jak `null` i `undefined` porównują się ze sobą? To zależy od operatora.
+**Luźne** porównanie `==` traktuje je jako to samo i uznaje je za różne od każdej innej wartości, w tym `0`, `""` i `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**Ścisłe** porównanie `===` porównuje także typ, a `null` i `undefined` mają różne typy:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Uzupełnij kod tak, aby pierwszy wiersz porównywał `missing` i `undefined` luźnym porównaniem, drugi wiersz porównaniem ścisłym, a trzeci wiersz sprawdzał wynik `typeof missing`, dając na wyjściu `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/pl/javascript/nullability/5.md
+++ b/pl/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+W większości przypadków nie obchodzi Cię, *który* z dwóch znaczników "braku wartości" otrzymałeś: chcesz po prostu wiedzieć, czy wartość w ogóle jest.
+Ponieważ `null == undefined` daje `true` i nic innego nie jest luźno równe `null`, porównanie `value == null` to standardowy idiom łapiący **oba** przypadki naraz:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+To jedyny przypadek, w którym `==` jest preferowane nad `===`: zapis `value === null || value === undefined` robi dokładnie to samo, tylko dłużej.
+Wartości takie jak `0`, `""` i `false` to *nie* `null`: to prawdziwe wartości, które po prostu są falsy.
+
+# --instructions--
+
+Napisz funkcję `isMissing(value)`, która zwraca `true`, gdy `value` to `null` lub `undefined`, oraz `false` dla każdej innej wartości
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` musi zwracać `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` i `isMissing()` muszą zwracać `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` musi zwracać `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` i `isMissing(false)` muszą zwracać `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` i `isMissing({})` muszą zwracać `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/pl/javascript/nullability/6.md
+++ b/pl/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Odczytanie właściwości z `null` lub `undefined` to błąd, który zatrzymuje program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` to `undefined`, a `undefined` nie ma żadnych właściwości. Operator **opcjonalnego łańcuchowania** `?.` rozwiązuje ten problem: jeśli wartość po jego lewej stronie to `null` lub `undefined`, całe wyrażenie się zatrzymuje i przyjmuje wartość `undefined` zamiast zgłaszać błąd:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Gdy lewa strona jednak ma wartość, `?.` zachowuje się dokładnie jak zwykła kropka `.`. Można łączyć ich kilka: `user.address?.street?.name` zwraca `undefined`, gdy tylko jakiekolwiek ogniwo jest brakujące.
+
+# --instructions--
+
+Uzupełnij kod tak, aby obie linie wypisywały `undefined` zamiast zgłaszać błąd, używając opcjonalnego łańcuchowania
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/pl/javascript/nullability/7.md
+++ b/pl/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Opcjonalne łańcuchowanie nie ogranicza się do właściwości po kropce. Istnieją jeszcze dwie formy.
+`?.[]` odczytuje element lub obliczony klucz tylko wtedy, gdy lewa strona ma wartość:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` wywołuje funkcję tylko wtedy, gdy ona istnieje, co jest wygodne dla opcjonalnych callbacków:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+W każdej formie sprawdzenie dotyczy wartości **tuż przed** `?.`: `post?.tags?.[0]` jest bezpieczne nawet wtedy, gdy samo `post` to `null` lub `undefined`.
+
+# --instructions--
+
+Napisz funkcję `firstTag(post)`, która zwraca pierwszy element `post.tags`, albo `undefined`, gdy `post` jest brakujące, nie ma `tags` lub jego tablica `tags` jest pusta, używając opcjonalnego łańcuchowania zamiast instrukcji `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` musi zwracać `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` musi zwracać `undefined`, ponieważ nie ma właściwości `tags`.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` musi zwracać `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` i `firstTag(undefined)` muszą zwracać `undefined` bez zgłaszania błędu.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+Funkcja musi używać opcjonalnego łańcuchowania i nie może używać `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/pl/javascript/nullability/8.md
+++ b/pl/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Gdy już wiesz, że wartość może być brakująca, zwykle chcesz w jej miejscu mieć wartość **domyślną**. Robią to dwa operatory, a różnią się tym, co uznają za "brakujące".
+`a || b` zwraca `b` zawsze, gdy `a` jest **falsy**: nie tylko `null` i `undefined`, ale też `0`, `""`, `false` i `NaN`.
+Operator **nullish coalescing** `a ?? b` zwraca `b` tylko wtedy, gdy `a` to `null` lub `undefined`, a każdą inną wartość zachowuje:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Używaj `??`, gdy `0`, `""` lub `false` to pełnoprawne wartości, które trzeba zachować, a `||`, gdy naprawdę chcesz zamienić każdą wartość falsy.
+
+# --instructions--
+
+Uzupełnij kod tak, aby pierwsza linia zachowała `0` zapisane w `count`, druga linia zamieniła puste `name` na `"Guest"`, a trzecia linia zachowała wartość `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/pl/javascript/nullability/9.md
+++ b/pl/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Bardzo częsty wzorzec to "wypełnij tę właściwość tylko wtedy, gdy nie jest jeszcze ustawiona". Zapisany z `??` powtarza nazwę:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Operator **przypisania nullish** `??=` robi to samo w jednym kroku: przypisuje prawą stronę tylko wtedy, gdy lewa strona ma obecnie wartość `null` lub `undefined`, a każdą inną wartość zostawia nietkniętą:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` pozostaje `0`, ponieważ `0` nie jest nullish; `timeout` nie istniał, więc otrzymuje `1000`. Ta sama idea istnieje dla `||` jako `||=`, które nadpisuje każdą wartość falsy.
+
+# --instructions--
+
+Co wypisze ten kod?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/pl/javascript/nullability/_theory.md
+++ b/pl/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript ma dwa różne sposoby na powiedzenie "nie ma tu żadnej wartości".
+`undefined` oznacza, że wartość **nigdy nie została dostarczona**. Zmienna zadeklarowana bez wartości przyjmuje `undefined`, i tak samo właściwość, która nie istnieje w obiekcie:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` to wartość, którą **Ty** przypisujesz celowo, aby powiedzieć "pusto, i wiem o tym":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Zatem `undefined` to zwykle język informujący Cię, że czegoś brakuje, podczas gdy `null` to programista stwierdzający, że coś jest celowo puste.
+
+---
+
+Funkcje dają `undefined` jeszcze w dwóch sytuacjach.
+Gdy wywołasz funkcję z **mniejszą liczbą argumentów**, niż deklaruje, brakujące parametry przyjmują `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Gdy funkcja kończy działanie **bez `return`** (lub z samym `return;`), jej wywołanie daje `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Zauważ, że jawne przekazanie `null` to nie to samo, co pominięcie argumentu: `greet(null)` wypisuje `null`, ponieważ `null` to prawdziwa wartość przekazana do funkcji.
+
+---
+
+Operator `typeof` zwraca typ wartości w postaci ciągu znaków. Dla `undefined` odpowiada `"undefined"`, zgodnie z oczekiwaniami:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Dla `null` odpowiada jednak `"object"`. To błąd z samej pierwszej wersji JavaScriptu, którego nigdy nie naprawiono, ponieważ zbyt dużo kodu od niego zależy:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Zatem `typeof` to niezawodny sposób wykrycia `undefined`, ale już nie `null`. Aby sprawdzić `null`, porównaj z nią bezpośrednio: `value === null`.
+
+---
+
+Jak `null` i `undefined` porównują się ze sobą? To zależy od operatora.
+**Luźne** porównanie `==` traktuje je jako to samo i uznaje je za różne od każdej innej wartości, w tym `0`, `""` i `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**Ścisłe** porównanie `===` porównuje także typ, a `null` i `undefined` mają różne typy:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+W większości przypadków nie obchodzi Cię, *który* z dwóch znaczników "braku wartości" otrzymałeś: chcesz po prostu wiedzieć, czy wartość w ogóle jest.
+Ponieważ `null == undefined` daje `true` i nic innego nie jest luźno równe `null`, porównanie `value == null` to standardowy idiom łapiący **oba** przypadki naraz:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+To jedyny przypadek, w którym `==` jest preferowane nad `===`: zapis `value === null || value === undefined` robi dokładnie to samo, tylko dłużej.
+Wartości takie jak `0`, `""` i `false` to *nie* `null`: to prawdziwe wartości, które po prostu są falsy.
+
+---
+
+Odczytanie właściwości z `null` lub `undefined` to błąd, który zatrzymuje program:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` to `undefined`, a `undefined` nie ma żadnych właściwości. Operator **opcjonalnego łańcuchowania** `?.` rozwiązuje ten problem: jeśli wartość po jego lewej stronie to `null` lub `undefined`, całe wyrażenie się zatrzymuje i przyjmuje wartość `undefined` zamiast zgłaszać błąd:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Gdy lewa strona jednak ma wartość, `?.` zachowuje się dokładnie jak zwykła kropka `.`. Można łączyć ich kilka: `user.address?.street?.name` zwraca `undefined`, gdy tylko jakiekolwiek ogniwo jest brakujące.
+
+---
+
+Opcjonalne łańcuchowanie nie ogranicza się do właściwości po kropce. Istnieją jeszcze dwie formy.
+`?.[]` odczytuje element lub obliczony klucz tylko wtedy, gdy lewa strona ma wartość:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` wywołuje funkcję tylko wtedy, gdy ona istnieje, co jest wygodne dla opcjonalnych callbacków:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+W każdej formie sprawdzenie dotyczy wartości **tuż przed** `?.`: `post?.tags?.[0]` jest bezpieczne nawet wtedy, gdy samo `post` to `null` lub `undefined`.
+
+---
+
+Gdy już wiesz, że wartość może być brakująca, zwykle chcesz w jej miejscu mieć wartość **domyślną**. Robią to dwa operatory, a różnią się tym, co uznają za "brakujące".
+`a || b` zwraca `b` zawsze, gdy `a` jest **falsy**: nie tylko `null` i `undefined`, ale też `0`, `""`, `false` i `NaN`.
+Operator **nullish coalescing** `a ?? b` zwraca `b` tylko wtedy, gdy `a` to `null` lub `undefined`, a każdą inną wartość zachowuje:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Używaj `??`, gdy `0`, `""` lub `false` to pełnoprawne wartości, które trzeba zachować, a `||`, gdy naprawdę chcesz zamienić każdą wartość falsy.
+
+---
+
+Bardzo częsty wzorzec to "wypełnij tę właściwość tylko wtedy, gdy nie jest jeszcze ustawiona". Zapisany z `??` powtarza nazwę:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Operator **przypisania nullish** `??=` robi to samo w jednym kroku: przypisuje prawą stronę tylko wtedy, gdy lewa strona ma obecnie wartość `null` lub `undefined`, a każdą inną wartość zostawia nietkniętą:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` pozostaje `0`, ponieważ `0` nie jest nullish; `timeout` nie istniał, więc otrzymuje `1000`. Ta sama idea istnieje dla `||` jako `||=`, które nadpisuje każdą wartość falsy.
+
+---
+
+**Parametr domyślny** nadaje parametrowi wartość, gdy wywołujący jej nie podaje. Zasada jest precyzyjna: wartość domyślna jest używana tylko wtedy, gdy argument to `undefined`, co obejmuje jego pominięcie. Przekazanie `null` **nie** uruchamia wartości domyślnej, ponieważ `null` to wartość:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Parametry domyślne stosują regułę `undefined`, podczas gdy `??` obejmuje i `null`, i `undefined`: wybierz to, które pasuje do sposobu wywoływania Twojej funkcji.
+
+---
+
+Opcjonalne łańcuchowanie i zabezpieczenie `== null` dobrze ze sobą współpracują: łańcuch odczytuje zagnieżdżoną wartość bez zgłaszania błędu, a zabezpieczenie decyduje, co zrobić, gdy wynik jest brakujący:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+W ostatnim `return` zwykła kropka `.` jest bezpieczna, ponieważ zabezpieczenie już udowodniło, że każde ogniwo istnieje.
+
+---
+
+Wiele wbudowanych metod zgłasza "niczego nie znaleziono", zwracając `undefined`. Metoda tablic `find(callback)` to typowy przykład: zwraca pierwszy element, dla którego callback daje `true`, albo `undefined`, gdy żaden element nie pasuje:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Odczytanie tutaj `found.price` zgłosiłoby błąd, więc `?.` i `??` to naturalni towarzysze `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` i `undefined` zachowują się różnie, gdy obiekt jest konwertowany do JSON za pomocą `JSON.stringify()`.
+JSON ma wartość `null`, ale nie ma `undefined`, więc właściwość o wartości `undefined` jest po prostu **pomijana**, a właściwość `null` jest zachowywana:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Wewnątrz tablic pozycje nie mogą zniknąć, więc tam `undefined` staje się `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Sprawdzenie `obj.key === undefined` nie potrafi odróżnić dwóch sytuacji: właściwość nie istnieje albo istnieje i przechowuje wartość `undefined`.
+`Object.hasOwn(obj, key)` odpowiada tylko na pierwsze pytanie: zwraca `true`, gdy obiekt ma **własną** właściwość o nazwie `key`, niezależnie od jej wartości:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Własna" oznacza zadeklarowaną na samym obiekcie: dziedziczone składowe, takie jak `toString`, są dostępne na każdym obiekcie, ale `Object.hasOwn(config, "toString")` daje `false`.

--- a/pt/javascript/data.json
+++ b/pt/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Arrow Functions",
         "description": "Aprenda como escrever funções anônimas curtas"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Nullability",
+        "description": "Aprenda como lidar com valores que podem ser null ou undefined"
     }
 }

--- a/pt/javascript/nullability/1.md
+++ b/pt/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript tem duas maneiras diferentes de dizer "não há valor aqui".
+`undefined` significa que um valor **nunca foi fornecido**. Uma variável declarada sem valor contém `undefined`, e o mesmo acontece com uma propriedade que não existe em um objeto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` é um valor que **você** atribui de propósito para dizer "vazio, e eu sei disso":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Assim, `undefined` geralmente é a linguagem informando que algo está faltando, enquanto `null` é o programador afirmando que algo está intencionalmente vazio.
+
+# --instructions--
+
+Complete o código para que `city` seja declarada sem valor e `owner` seja explicitamente definido como `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/pt/javascript/nullability/10.md
+++ b/pt/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Um **parâmetro padrão** dá a um parâmetro um valor quando quem chama não fornece um. A regra é precisa: o padrão é usado apenas quando o argumento é `undefined`, o que inclui omiti-lo. Passar `null` **não** aciona o padrão, porque `null` é um valor:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Parâmetros padrão seguem a regra do `undefined`, enquanto `??` cobre tanto `null` quanto `undefined`: escolha o que corresponder à forma como sua função será chamada.
+
+# --instructions--
+
+Escreva uma função `pad(text, width = 5)` que retorna `text` seguido de quantos caracteres `"."` forem necessários para atingir `width` caracteres, usando um parâmetro padrão para `width`; quando `text` já tiver `width` caracteres ou mais, retorne-o sem alterações
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` deve retornar `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` deve retornar `"ab..."`, usando a largura padrão de `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` também deve usar a largura padrão.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` deve retornar `"ab"`, porque `null` não aciona o padrão e é convertido para `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` deve retornar `"abcdef"` sem alterações.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` deve ser declarado como um parâmetro padrão.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/pt/javascript/nullability/11.md
+++ b/pt/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+O encadeamento opcional e a proteção `== null` funcionam bem juntos: o encadeamento lê o valor aninhado sem lançar erro, e a proteção decide o que fazer quando o resultado está ausente:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro do último `return` um `.` simples é seguro, porque a proteção já provou que todos os elos existem.
+
+# --instructions--
+
+Ordene as linhas para definir `cityOf`, que retorna `"unknown"` quando o usuário não tem cidade e a cidade caso contrário, depois imprima o resultado para um usuário sem endereço e para um usuário que mora em `Rome`. Defina a função primeiro
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/pt/javascript/nullability/12.md
+++ b/pt/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Muitos métodos embutidos relatam "nada encontrado" retornando `undefined`. O método de array `find(callback)` é o exemplo típico: ele retorna o primeiro elemento para o qual o callback é `true`, ou `undefined` quando nenhum elemento corresponde:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Ler `found.price` aqui lançaria um erro, então `?.` e `??` são os companheiros naturais do `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Escreva uma função `priceOf(products, name)` que retorna o `price` do produto de `products` cujo `name` corresponde, ou `null` quando não há tal produto, usando `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` deve retornar `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` deve retornar `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` deve retornar `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` deve retornar `0`, não `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+A função deve usar `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/pt/javascript/nullability/13.md
+++ b/pt/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` e `undefined` se comportam de forma diferente quando um objeto é convertido para JSON com `JSON.stringify()`.
+JSON tem um valor `null` mas não tem `undefined`, então uma propriedade cujo valor é `undefined` é simplesmente **omitida**, enquanto uma propriedade `null` é mantida:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro de arrays as posições não podem desaparecer, então `undefined` se torna `null` lá:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+O que este código imprime?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/pt/javascript/nullability/14.md
+++ b/pt/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Verificar `obj.key === undefined` não consegue distinguir duas situações: a propriedade não existe, ou ela existe e contém o valor `undefined`.
+`Object.hasOwn(obj, key)` responde apenas à primeira pergunta: ele retorna `true` quando o objeto tem sua **própria** propriedade chamada `key`, seja qual for seu valor:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Própria" significa declarada no próprio objeto: membros herdados como `toString` estão disponíveis em todo objeto, mas `Object.hasOwn(config, "toString")` é `false`.
+
+# --instructions--
+
+Escreva uma função `describeKey(obj, key)` que retorna `"missing"` quando `obj` não tem a propriedade própria `key`, `"empty"` quando a propriedade existe mas contém `null` ou `undefined`, e `"set"` em todos os outros casos, usando `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` deve retornar `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` e `describeKey({ a: "" }, "a")` devem retornar `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` e `describeKey({ a: null }, "a")` devem retornar `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` deve retornar `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` deve retornar `"missing"`, porque `toString` é herdado, não próprio.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+A função deve usar `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/pt/javascript/nullability/15.md
+++ b/pt/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Ordene as linhas para definir `finish`, que chama o callback opcional `onDone` de uma tarefa e retorna seu `name` ou `"untitled"`, depois imprima o resultado para uma tarefa chamada `build` com um callback que imprime `done`, e para uma tarefa vazia. Defina a função primeiro
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/pt/javascript/nullability/16.md
+++ b/pt/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Escreva uma função `pick(obj, path, fallback)` onde `path` é uma string de nomes de propriedades separados por pontos, como `"address.city"`; ela deve retornar o valor aninhado encontrado seguindo o caminho, ou `fallback` quando qualquer passo ou o valor final for `null` ou `undefined`; valores como `0`, `""` e `false` devem ser retornados como são
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` deve retornar `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` deve retornar `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` deve retornar `0` sem lançar erro.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` deve retornar `0` e `pick({ name: "" }, "name", "anon")` deve retornar `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` deve retornar `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` e `pick({ x: undefined }, "x", "none")` devem retornar `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/pt/javascript/nullability/2.md
+++ b/pt/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Funções produzem `undefined` em mais duas situações.
+Quando você chama uma função com **menos argumentos** do que ela declara, os parâmetros ausentes contêm `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quando uma função termina **sem um `return`** (ou com um simples `return;`), chamá-la resulta em `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Observe que passar `null` explicitamente não é o mesmo que omitir o argumento: `greet(null)` imprime `null`, porque `null` é um valor real que foi entregue à função.
+
+# --instructions--
+
+Escreva uma função `nameOrGuest(name)` que retorna `"Guest"` quando `name` é `undefined` (por exemplo, porque o argumento foi omitido) e retorna `name` sem alterações em todos os outros casos, incluindo `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` deve retornar `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` deve retornar `"Guest"`, porque o argumento ausente é `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` deve retornar `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` deve retornar `null`, porque `null` é um valor que foi passado de propósito.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` deve retornar `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/pt/javascript/nullability/3.md
+++ b/pt/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+O operador `typeof` retorna o tipo de um valor como uma string. Para `undefined` ele responde `"undefined"`, como você esperaria:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Para `null`, porém, ele responde `"object"`. Este é um bug da primeiríssima versão de JavaScript que nunca foi corrigido, porque código demais depende dele:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Portanto, `typeof` é uma maneira confiável de detectar `undefined`, mas não `null`. Para verificar `null`, compare diretamente com ele: `value === null`.
+
+# --instructions--
+
+O que este código imprime?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/pt/javascript/nullability/4.md
+++ b/pt/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Como `null` e `undefined` se comparam entre si? Depende do operador.
+A igualdade **frouxa** `==` os trata como a mesma coisa, e os considera diferentes de qualquer outro valor, incluindo `0`, `""` e `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+A igualdade **estrita** `===` também compara o tipo, e `null` e `undefined` têm tipos diferentes:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Complete o código para que a primeira linha compare `missing` e `undefined` com a igualdade frouxa, a segunda linha com a igualdade estrita, e a terceira linha verifique o resultado de `typeof missing`, produzindo a saída `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/pt/javascript/nullability/5.md
+++ b/pt/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Na maioria das vezes você não se importa *qual* dos dois marcadores de "sem valor" você recebeu: você só quer saber se há um valor.
+Como `null == undefined` é `true` e nada mais é frouxamente igual a `null`, a comparação `value == null` é a construção idiomática padrão para capturar **ambos** de uma vez:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Este é o único caso em que `==` é preferível a `===`: escrever `value === null || value === undefined` faz exatamente o mesmo trabalho, apenas mais longo.
+Valores como `0`, `""` e `false` *não* são `null`: são valores reais que por acaso são falsy.
+
+# --instructions--
+
+Escreva uma função `isMissing(value)` que retorna `true` quando `value` é `null` ou `undefined`, e `false` para qualquer outro valor
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` deve retornar `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` e `isMissing()` devem retornar `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` deve retornar `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` e `isMissing(false)` devem retornar `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` e `isMissing({})` devem retornar `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/pt/javascript/nullability/6.md
+++ b/pt/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Ler uma propriedade de `null` ou `undefined` é um erro que interrompe o programa:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` é `undefined`, e `undefined` não tem propriedades. O operador de **encadeamento opcional** (optional chaining) `?.` resolve isso: se o valor à sua esquerda for `null` ou `undefined`, a expressão inteira para e avalia como `undefined` em vez de lançar um erro:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quando o lado esquerdo tem um valor, `?.` se comporta exatamente como um `.` normal. Você pode encadear vários: `user.address?.street?.name` retorna `undefined` assim que qualquer elo estiver faltando.
+
+# --instructions--
+
+Complete o código para que ambas as linhas imprimam `undefined` em vez de lançar um erro, usando encadeamento opcional
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/pt/javascript/nullability/7.md
+++ b/pt/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+O encadeamento opcional não se limita a propriedades com ponto. Há mais duas formas.
+`?.[]` lê um elemento ou uma chave computada apenas quando o lado esquerdo tem um valor:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` chama uma função apenas quando ela existe, o que é útil para callbacks opcionais:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+Em todas as formas, a verificação se aplica ao valor **imediatamente antes** do `?.`: `post?.tags?.[0]` é seguro mesmo quando o próprio `post` é `null` ou `undefined`.
+
+# --instructions--
+
+Escreva uma função `firstTag(post)` que retorna o primeiro elemento de `post.tags`, ou `undefined` quando `post` está ausente, não tem `tags`, ou seu array `tags` está vazio, usando encadeamento opcional em vez de instruções `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` deve retornar `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` deve retornar `undefined`, porque não há propriedade `tags`.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` deve retornar `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` e `firstTag(undefined)` devem retornar `undefined` sem lançar erro.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+A função deve usar encadeamento opcional e nenhum `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/pt/javascript/nullability/8.md
+++ b/pt/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Quando você sabe que um valor pode estar ausente, geralmente quer um **padrão** em seu lugar. Dois operadores fazem isso, e eles diferem no que consideram "ausente".
+`a || b` retorna `b` sempre que `a` for **falsy**: não apenas `null` e `undefined`, mas também `0`, `""`, `false` e `NaN`.
+O operador de **coalescência nula** (nullish coalescing) `a ?? b` retorna `b` apenas quando `a` é `null` ou `undefined`, e mantém qualquer outro valor:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` quando `0`, `""` ou `false` forem valores legítimos que devem ser mantidos, e `||` quando você realmente quiser substituir todo valor falsy.
+
+# --instructions--
+
+Complete o código para que a primeira linha mantenha o `0` armazenado em `count`, a segunda linha substitua o `name` vazio por `"Guest"`, e a terceira linha mantenha o valor `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/pt/javascript/nullability/9.md
+++ b/pt/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Um padrão muito comum é "preencher esta propriedade apenas se ela ainda não estiver definida". Escrito com `??`, ele repete o nome:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+O operador de **atribuição nula** (nullish assignment) `??=` faz o mesmo em um passo: ele atribui o lado direito apenas quando o lado esquerdo está atualmente `null` ou `undefined`, e deixa qualquer outro valor intocado:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` permanece `0` porque `0` não é nullish; `timeout` não existia, então recebe `1000`. A mesma ideia existe para `||` como `||=`, que sobrescreve todo valor falsy.
+
+# --instructions--
+
+O que este código imprime?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/pt/javascript/nullability/_theory.md
+++ b/pt/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript tem duas maneiras diferentes de dizer "não há valor aqui".
+`undefined` significa que um valor **nunca foi fornecido**. Uma variável declarada sem valor contém `undefined`, e o mesmo acontece com uma propriedade que não existe em um objeto:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` é um valor que **você** atribui de propósito para dizer "vazio, e eu sei disso":
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Assim, `undefined` geralmente é a linguagem informando que algo está faltando, enquanto `null` é o programador afirmando que algo está intencionalmente vazio.
+
+---
+
+Funções produzem `undefined` em mais duas situações.
+Quando você chama uma função com **menos argumentos** do que ela declara, os parâmetros ausentes contêm `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Quando uma função termina **sem um `return`** (ou com um simples `return;`), chamá-la resulta em `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Observe que passar `null` explicitamente não é o mesmo que omitir o argumento: `greet(null)` imprime `null`, porque `null` é um valor real que foi entregue à função.
+
+---
+
+O operador `typeof` retorna o tipo de um valor como uma string. Para `undefined` ele responde `"undefined"`, como você esperaria:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Para `null`, porém, ele responde `"object"`. Este é um bug da primeiríssima versão de JavaScript que nunca foi corrigido, porque código demais depende dele:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Portanto, `typeof` é uma maneira confiável de detectar `undefined`, mas não `null`. Para verificar `null`, compare diretamente com ele: `value === null`.
+
+---
+
+Como `null` e `undefined` se comparam entre si? Depende do operador.
+A igualdade **frouxa** `==` os trata como a mesma coisa, e os considera diferentes de qualquer outro valor, incluindo `0`, `""` e `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+A igualdade **estrita** `===` também compara o tipo, e `null` e `undefined` têm tipos diferentes:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+Na maioria das vezes você não se importa *qual* dos dois marcadores de "sem valor" você recebeu: você só quer saber se há um valor.
+Como `null == undefined` é `true` e nada mais é frouxamente igual a `null`, a comparação `value == null` é a construção idiomática padrão para capturar **ambos** de uma vez:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Este é o único caso em que `==` é preferível a `===`: escrever `value === null || value === undefined` faz exatamente o mesmo trabalho, apenas mais longo.
+Valores como `0`, `""` e `false` *não* são `null`: são valores reais que por acaso são falsy.
+
+---
+
+Ler uma propriedade de `null` ou `undefined` é um erro que interrompe o programa:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` é `undefined`, e `undefined` não tem propriedades. O operador de **encadeamento opcional** (optional chaining) `?.` resolve isso: se o valor à sua esquerda for `null` ou `undefined`, a expressão inteira para e avalia como `undefined` em vez de lançar um erro:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Quando o lado esquerdo tem um valor, `?.` se comporta exatamente como um `.` normal. Você pode encadear vários: `user.address?.street?.name` retorna `undefined` assim que qualquer elo estiver faltando.
+
+---
+
+O encadeamento opcional não se limita a propriedades com ponto. Há mais duas formas.
+`?.[]` lê um elemento ou uma chave computada apenas quando o lado esquerdo tem um valor:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` chama uma função apenas quando ela existe, o que é útil para callbacks opcionais:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+Em todas as formas, a verificação se aplica ao valor **imediatamente antes** do `?.`: `post?.tags?.[0]` é seguro mesmo quando o próprio `post` é `null` ou `undefined`.
+
+---
+
+Quando você sabe que um valor pode estar ausente, geralmente quer um **padrão** em seu lugar. Dois operadores fazem isso, e eles diferem no que consideram "ausente".
+`a || b` retorna `b` sempre que `a` for **falsy**: não apenas `null` e `undefined`, mas também `0`, `""`, `false` e `NaN`.
+O operador de **coalescência nula** (nullish coalescing) `a ?? b` retorna `b` apenas quando `a` é `null` ou `undefined`, e mantém qualquer outro valor:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Use `??` quando `0`, `""` ou `false` forem valores legítimos que devem ser mantidos, e `||` quando você realmente quiser substituir todo valor falsy.
+
+---
+
+Um padrão muito comum é "preencher esta propriedade apenas se ela ainda não estiver definida". Escrito com `??`, ele repete o nome:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+O operador de **atribuição nula** (nullish assignment) `??=` faz o mesmo em um passo: ele atribui o lado direito apenas quando o lado esquerdo está atualmente `null` ou `undefined`, e deixa qualquer outro valor intocado:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` permanece `0` porque `0` não é nullish; `timeout` não existia, então recebe `1000`. A mesma ideia existe para `||` como `||=`, que sobrescreve todo valor falsy.
+
+---
+
+Um **parâmetro padrão** dá a um parâmetro um valor quando quem chama não fornece um. A regra é precisa: o padrão é usado apenas quando o argumento é `undefined`, o que inclui omiti-lo. Passar `null` **não** aciona o padrão, porque `null` é um valor:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Parâmetros padrão seguem a regra do `undefined`, enquanto `??` cobre tanto `null` quanto `undefined`: escolha o que corresponder à forma como sua função será chamada.
+
+---
+
+O encadeamento opcional e a proteção `== null` funcionam bem juntos: o encadeamento lê o valor aninhado sem lançar erro, e a proteção decide o que fazer quando o resultado está ausente:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Dentro do último `return` um `.` simples é seguro, porque a proteção já provou que todos os elos existem.
+
+---
+
+Muitos métodos embutidos relatam "nada encontrado" retornando `undefined`. O método de array `find(callback)` é o exemplo típico: ele retorna o primeiro elemento para o qual o callback é `true`, ou `undefined` quando nenhum elemento corresponde:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Ler `found.price` aqui lançaria um erro, então `?.` e `??` são os companheiros naturais do `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` e `undefined` se comportam de forma diferente quando um objeto é convertido para JSON com `JSON.stringify()`.
+JSON tem um valor `null` mas não tem `undefined`, então uma propriedade cujo valor é `undefined` é simplesmente **omitida**, enquanto uma propriedade `null` é mantida:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Dentro de arrays as posições não podem desaparecer, então `undefined` se torna `null` lá:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Verificar `obj.key === undefined` não consegue distinguir duas situações: a propriedade não existe, ou ela existe e contém o valor `undefined`.
+`Object.hasOwn(obj, key)` responde apenas à primeira pergunta: ele retorna `true` quando o objeto tem sua **própria** propriedade chamada `key`, seja qual for seu valor:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"Própria" significa declarada no próprio objeto: membros herdados como `toString` estão disponíveis em todo objeto, mas `Object.hasOwn(config, "toString")` é `false`.

--- a/ru/javascript/data.json
+++ b/ru/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "Стрелочные функции",
         "description": "Узнайте, как писать короткие анонимные функции"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "Работа с null и undefined",
+        "description": "Узнайте, как обрабатывать значения, которые могут быть null или undefined"
     }
 }

--- a/ru/javascript/nullability/1.md
+++ b/ru/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+В JavaScript есть два разных способа сказать «здесь нет значения».
+`undefined` означает, что значение **не было задано вовсе**. Переменная, объявленная без значения, содержит `undefined`, как и свойство, отсутствующее в объекте:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` — это значение, которое **вы** присваиваете намеренно, чтобы сказать «здесь пусто, и я это знаю»:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Итак, `undefined` — это обычно язык, сообщающий вам, что чего-то не хватает, а `null` — способ программиста заявить, что значение пусто намеренно.
+
+# --instructions--
+
+Дополните код так, чтобы `city` была объявлена без значения, а `owner` был явно установлен в `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/ru/javascript/nullability/10.md
+++ b/ru/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+**Параметр по умолчанию** даёт параметру значение, когда вызывающий его не предоставляет. Правило точное: значение по умолчанию используется только тогда, когда аргумент равен `undefined`, что включает и его пропуск. Передача `null` **не** запускает значение по умолчанию, потому что `null` — это значение:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Параметры по умолчанию следуют правилу `undefined`, тогда как `??` покрывает и `null`, и `undefined`: выбирайте то, что соответствует тому, как ваша функция будет вызываться.
+
+# --instructions--
+
+Напишите функцию `pad(text, width = 5)`, которая возвращает `text`, дополненный таким количеством символов `"."`, чтобы достичь `width` символов, используя параметр по умолчанию для `width`; когда `text` уже имеет `width` символов или длиннее, верните его без изменений
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` должна возвращать `"ab.."`.
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` должна возвращать `"ab..."`, используя ширину по умолчанию `5`.
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` также должна использовать ширину по умолчанию.
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` должна возвращать `"ab"`, потому что `null` не запускает значение по умолчанию и преобразуется в `0`.
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` должна возвращать `"abcdef"` без изменений.
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` должен быть объявлен как параметр по умолчанию.
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/ru/javascript/nullability/11.md
+++ b/ru/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+Опциональная цепочка и проверка `== null` хорошо работают вместе: цепочка читает вложенное значение без выбрасывания ошибки, а проверка решает, что делать, когда результат отсутствует:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Внутри последнего `return` обычная точка `.` безопасна, потому что проверка уже доказала, что каждое звено существует.
+
+# --instructions--
+
+Упорядочьте строки так, чтобы определить `cityOf`, которая возвращает `"unknown"`, когда у пользователя нет города, и город в противном случае, затем выведите результат для пользователя без адреса и для пользователя, живущего в `Rome`. Сначала определите функцию
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/ru/javascript/nullability/12.md
+++ b/ru/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Многие встроенные методы сообщают «ничего не найдено», возвращая `undefined`. Метод массивов `find(callback)` — типичный пример: он возвращает первый элемент, для которого колбэк равен `true`, или `undefined`, когда ни один элемент не подходит:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Чтение `found.price` здесь выбросило бы ошибку, поэтому `?.` и `??` — естественные спутники `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+Напишите функцию `priceOf(products, name)`, которая возвращает `price` продукта из `products`, чей `name` совпадает, или `null`, когда такого продукта нет, используя `find`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` должна возвращать `7`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` должна возвращать `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` должна возвращать `null`.
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` должна возвращать `0`, а не `null`.
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+Функция должна использовать `find`.
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/ru/javascript/nullability/13.md
+++ b/ru/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`null` и `undefined` ведут себя по-разному, когда объект преобразуется в JSON с помощью `JSON.stringify()`.
+В JSON есть значение `null`, но нет `undefined`, поэтому свойство со значением `undefined` просто **пропускается**, а свойство `null` сохраняется:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Внутри массивов позиции не могут исчезнуть, поэтому там `undefined` становится `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+Каков результат выполнения следующего кода?
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/ru/javascript/nullability/14.md
+++ b/ru/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Проверка `obj.key === undefined` не может различить две ситуации: свойство не существует, или оно существует и содержит значение `undefined`.
+`Object.hasOwn(obj, key)` отвечает только на первый вопрос: он возвращает `true`, когда у объекта есть **собственное** свойство с именем `key`, каковым бы ни было его значение:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+«Собственное» означает объявленное на самом объекте: унаследованные члены, такие как `toString`, доступны у каждого объекта, но `Object.hasOwn(config, "toString")` даёт `false`.
+
+# --instructions--
+
+Напишите функцию `describeKey(obj, key)`, которая возвращает `"missing"`, когда у `obj` нет собственного свойства `key`, `"empty"`, когда свойство существует, но содержит `null` или `undefined`, и `"set"` во всех остальных случаях, используя `Object.hasOwn`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` должна возвращать `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` и `describeKey({ a: "" }, "a")` должны возвращать `"set"`.
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` и `describeKey({ a: null }, "a")` должны возвращать `"empty"`.
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` должна возвращать `"missing"`.
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` должна возвращать `"missing"`, потому что `toString` унаследован, а не является собственным.
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+Функция должна использовать `Object.hasOwn`.
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/ru/javascript/nullability/15.md
+++ b/ru/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+Упорядочьте строки так, чтобы определить `finish`, которая вызывает опциональный колбэк `onDone` задачи и возвращает её `name` или `"untitled"`, затем выведите результат для задачи с именем `build` и колбэком, выводящим `done`, и для пустой задачи. Сначала определите функцию
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/ru/javascript/nullability/16.md
+++ b/ru/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+Напишите функцию `pick(obj, path, fallback)`, где `path` — строка имён свойств, разделённых точками, например `"address.city"`; она должна возвращать вложенное значение, найденное по пути, или `fallback`, когда любой шаг или итоговое значение равно `null` или `undefined`; значения вроде `0`, `""` и `false` должны возвращаться как есть
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` должна возвращать `"Rome"`.
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` должна возвращать `"unknown"`.
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` должна возвращать `0` без выбрасывания ошибки.
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` должна возвращать `0`, а `pick({ name: "" }, "name", "anon")` должна возвращать `""`.
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` должна возвращать `false`.
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` и `pick({ x: undefined }, "x", "none")` должны возвращать `"none"`.
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/ru/javascript/nullability/2.md
+++ b/ru/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Функции дают `undefined` ещё в двух ситуациях.
+Когда вы вызываете функцию с **меньшим числом аргументов**, чем она объявляет, пропущенные параметры содержат `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Когда функция завершается **без `return`** (или с пустым `return;`), её вызов даёт `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Обратите внимание, что явная передача `null` — не то же самое, что пропуск аргумента: `greet(null)` выводит `null`, потому что `null` — это настоящее значение, переданное функции.
+
+# --instructions--
+
+Напишите функцию `nameOrGuest(name)`, которая возвращает `"Guest"`, когда `name` равно `undefined` (например, потому что аргумент был опущен), и возвращает `name` без изменений во всех остальных случаях, включая `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` должна возвращать `"Ana"`.
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` должна возвращать `"Guest"`, потому что пропущенный аргумент равен `undefined`.
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` должна возвращать `"Guest"`.
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` должна возвращать `null`, потому что `null` — это значение, переданное намеренно.
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` должна возвращать `""`.
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/ru/javascript/nullability/3.md
+++ b/ru/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Оператор `typeof` возвращает тип значения в виде строки. Для `undefined` он отвечает `"undefined"`, как и ожидается:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Для `null`, однако, он отвечает `"object"`. Это ошибка из самой первой версии JavaScript, которую так и не исправили, потому что слишком много кода от неё зависит:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Итак, `typeof` — надёжный способ обнаружить `undefined`, но не `null`. Чтобы проверить на `null`, сравните с ним напрямую: `value === null`.
+
+# --instructions--
+
+Каков результат выполнения следующего кода?
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/ru/javascript/nullability/4.md
+++ b/ru/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Как сравниваются между собой `null` и `undefined`? Это зависит от оператора.
+**Нестрогое** равенство `==` считает их одним и тем же, но отличными от любого другого значения, включая `0`, `""` и `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**Строгое** равенство `===` сравнивает ещё и тип, а у `null` и `undefined` разные типы:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+Дополните код так, чтобы первая строка сравнивала `missing` и `undefined` с помощью нестрогого равенства, вторая — с помощью строгого, а третья проверяла результат `typeof missing`, давая вывод `true`, `false`, `true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/ru/javascript/nullability/5.md
+++ b/ru/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+В большинстве случаев вам неважно, *какой именно* из двух маркеров «нет значения» вы получили: вы просто хотите знать, есть ли значение.
+Поскольку `null == undefined` даёт `true` и ничто другое не равно нестрого `null`, сравнение `value == null` — стандартный приём, чтобы поймать **оба** значения сразу:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Это единственный случай, когда `==` предпочитают `===`: запись `value === null || value === undefined` делает ровно то же самое, только длиннее.
+Значения вроде `0`, `""` и `false` — *не* `null`: это настоящие значения, которые просто оказываются falsy.
+
+# --instructions--
+
+Напишите функцию `isMissing(value)`, которая возвращает `true`, когда `value` равно `null` или `undefined`, и `false` для любого другого значения
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` должна возвращать `true`.
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` и `isMissing()` должны возвращать `true`.
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` должна возвращать `false`.
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` и `isMissing(false)` должны возвращать `false`.
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` и `isMissing({})` должны возвращать `false`.
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/ru/javascript/nullability/6.md
+++ b/ru/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Чтение свойства у `null` или `undefined` — это ошибка, которая останавливает программу:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` — это `undefined`, а у `undefined` нет свойств. Оператор **опциональной цепочки** `?.` решает эту проблему: если значение слева от него равно `null` или `undefined`, всё выражение останавливается и вычисляется в `undefined` вместо выбрасывания ошибки:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Когда слева всё же есть значение, `?.` ведёт себя в точности как обычная точка `.`. Можно объединять несколько: `user.address?.street?.name` возвращает `undefined`, как только какое-либо звено отсутствует.
+
+# --instructions--
+
+Дополните код так, чтобы обе строки выводили `undefined` вместо выбрасывания ошибки, используя опциональную цепочку
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/ru/javascript/nullability/7.md
+++ b/ru/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+Опциональная цепочка не ограничивается свойствами через точку. Есть ещё две формы.
+`?.[]` читает элемент или вычисляемый ключ только тогда, когда слева есть значение:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` вызывает функцию, только если она существует, что удобно для опциональных колбэков:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+В любой форме проверка применяется к значению **непосредственно перед** `?.`: `post?.tags?.[0]` безопасно, даже когда сам `post` равен `null` или `undefined`.
+
+# --instructions--
+
+Напишите функцию `firstTag(post)`, которая возвращает первый элемент `post.tags` или `undefined`, когда `post` отсутствует, не имеет `tags` или его массив `tags` пуст, используя опциональную цепочку вместо инструкций `if`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` должна возвращать `"js"`.
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` должна возвращать `undefined`, потому что свойства `tags` нет.
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` должна возвращать `undefined`.
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` и `firstTag(undefined)` должны возвращать `undefined` без выбрасывания ошибки.
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+Функция должна использовать опциональную цепочку и не использовать `if`.
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/ru/javascript/nullability/8.md
+++ b/ru/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+Когда вы знаете, что значение может отсутствовать, обычно вы хотите подставить на его место **значение по умолчанию**. Это делают два оператора, и они различаются в том, что считают «отсутствующим».
+`a || b` возвращает `b` всякий раз, когда `a` **falsy**: не только `null` и `undefined`, но и `0`, `""`, `false` и `NaN`.
+Оператор **нулевого слияния** `a ?? b` возвращает `b`, только когда `a` равно `null` или `undefined`, и сохраняет любое другое значение:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Используйте `??`, когда `0`, `""` или `false` — легитимные значения, которые нужно сохранить, и `||`, когда вы действительно хотите заменить каждое falsy-значение.
+
+# --instructions--
+
+Дополните код так, чтобы первая строка сохранила `0`, хранящийся в `count`, вторая строка заменила пустую `name` на `"Guest"`, а третья строка сохранила значение `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/ru/javascript/nullability/9.md
+++ b/ru/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+Очень распространённый шаблон — «заполнить это свойство, только если оно ещё не задано». Записанный с `??`, он повторяет имя:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Оператор **нулевого присваивания** `??=` делает то же самое за один шаг: он присваивает правую часть, только когда левая часть сейчас `null` или `undefined`, и не трогает любое другое значение:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` остаётся `0`, потому что `0` — не nullish; `timeout` не существовало, поэтому оно получает `1000`. Та же идея существует для `||` в виде `||=`, который перезаписывает каждое falsy-значение.
+
+# --instructions--
+
+Каков результат выполнения следующего кода?
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/ru/javascript/nullability/_theory.md
+++ b/ru/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+В JavaScript есть два разных способа сказать «здесь нет значения».
+`undefined` означает, что значение **не было задано вовсе**. Переменная, объявленная без значения, содержит `undefined`, как и свойство, отсутствующее в объекте:
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` — это значение, которое **вы** присваиваете намеренно, чтобы сказать «здесь пусто, и я это знаю»:
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+Итак, `undefined` — это обычно язык, сообщающий вам, что чего-то не хватает, а `null` — способ программиста заявить, что значение пусто намеренно.
+
+---
+
+Функции дают `undefined` ещё в двух ситуациях.
+Когда вы вызываете функцию с **меньшим числом аргументов**, чем она объявляет, пропущенные параметры содержат `undefined`:
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+Когда функция завершается **без `return`** (или с пустым `return;`), её вызов даёт `undefined`:
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+Обратите внимание, что явная передача `null` — не то же самое, что пропуск аргумента: `greet(null)` выводит `null`, потому что `null` — это настоящее значение, переданное функции.
+
+---
+
+Оператор `typeof` возвращает тип значения в виде строки. Для `undefined` он отвечает `"undefined"`, как и ожидается:
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+Для `null`, однако, он отвечает `"object"`. Это ошибка из самой первой версии JavaScript, которую так и не исправили, потому что слишком много кода от неё зависит:
+```javascript
+console.log(typeof null);
+// prints object
+```
+Итак, `typeof` — надёжный способ обнаружить `undefined`, но не `null`. Чтобы проверить на `null`, сравните с ним напрямую: `value === null`.
+
+---
+
+Как сравниваются между собой `null` и `undefined`? Это зависит от оператора.
+**Нестрогое** равенство `==` считает их одним и тем же, но отличными от любого другого значения, включая `0`, `""` и `false`:
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**Строгое** равенство `===` сравнивает ещё и тип, а у `null` и `undefined` разные типы:
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+В большинстве случаев вам неважно, *какой именно* из двух маркеров «нет значения» вы получили: вы просто хотите знать, есть ли значение.
+Поскольку `null == undefined` даёт `true` и ничто другое не равно нестрого `null`, сравнение `value == null` — стандартный приём, чтобы поймать **оба** значения сразу:
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+Это единственный случай, когда `==` предпочитают `===`: запись `value === null || value === undefined` делает ровно то же самое, только длиннее.
+Значения вроде `0`, `""` и `false` — *не* `null`: это настоящие значения, которые просто оказываются falsy.
+
+---
+
+Чтение свойства у `null` или `undefined` — это ошибка, которая останавливает программу:
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` — это `undefined`, а у `undefined` нет свойств. Оператор **опциональной цепочки** `?.` решает эту проблему: если значение слева от него равно `null` или `undefined`, всё выражение останавливается и вычисляется в `undefined` вместо выбрасывания ошибки:
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+Когда слева всё же есть значение, `?.` ведёт себя в точности как обычная точка `.`. Можно объединять несколько: `user.address?.street?.name` возвращает `undefined`, как только какое-либо звено отсутствует.
+
+---
+
+Опциональная цепочка не ограничивается свойствами через точку. Есть ещё две формы.
+`?.[]` читает элемент или вычисляемый ключ только тогда, когда слева есть значение:
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` вызывает функцию, только если она существует, что удобно для опциональных колбэков:
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+В любой форме проверка применяется к значению **непосредственно перед** `?.`: `post?.tags?.[0]` безопасно, даже когда сам `post` равен `null` или `undefined`.
+
+---
+
+Когда вы знаете, что значение может отсутствовать, обычно вы хотите подставить на его место **значение по умолчанию**. Это делают два оператора, и они различаются в том, что считают «отсутствующим».
+`a || b` возвращает `b` всякий раз, когда `a` **falsy**: не только `null` и `undefined`, но и `0`, `""`, `false` и `NaN`.
+Оператор **нулевого слияния** `a ?? b` возвращает `b`, только когда `a` равно `null` или `undefined`, и сохраняет любое другое значение:
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+Используйте `??`, когда `0`, `""` или `false` — легитимные значения, которые нужно сохранить, и `||`, когда вы действительно хотите заменить каждое falsy-значение.
+
+---
+
+Очень распространённый шаблон — «заполнить это свойство, только если оно ещё не задано». Записанный с `??`, он повторяет имя:
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+Оператор **нулевого присваивания** `??=` делает то же самое за один шаг: он присваивает правую часть, только когда левая часть сейчас `null` или `undefined`, и не трогает любое другое значение:
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` остаётся `0`, потому что `0` — не nullish; `timeout` не существовало, поэтому оно получает `1000`. Та же идея существует для `||` в виде `||=`, который перезаписывает каждое falsy-значение.
+
+---
+
+**Параметр по умолчанию** даёт параметру значение, когда вызывающий его не предоставляет. Правило точное: значение по умолчанию используется только тогда, когда аргумент равен `undefined`, что включает и его пропуск. Передача `null` **не** запускает значение по умолчанию, потому что `null` — это значение:
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+Параметры по умолчанию следуют правилу `undefined`, тогда как `??` покрывает и `null`, и `undefined`: выбирайте то, что соответствует тому, как ваша функция будет вызываться.
+
+---
+
+Опциональная цепочка и проверка `== null` хорошо работают вместе: цепочка читает вложенное значение без выбрасывания ошибки, а проверка решает, что делать, когда результат отсутствует:
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+Внутри последнего `return` обычная точка `.` безопасна, потому что проверка уже доказала, что каждое звено существует.
+
+---
+
+Многие встроенные методы сообщают «ничего не найдено», возвращая `undefined`. Метод массивов `find(callback)` — типичный пример: он возвращает первый элемент, для которого колбэк равен `true`, или `undefined`, когда ни один элемент не подходит:
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+Чтение `found.price` здесь выбросило бы ошибку, поэтому `?.` и `??` — естественные спутники `find`:
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+`null` и `undefined` ведут себя по-разному, когда объект преобразуется в JSON с помощью `JSON.stringify()`.
+В JSON есть значение `null`, но нет `undefined`, поэтому свойство со значением `undefined` просто **пропускается**, а свойство `null` сохраняется:
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+Внутри массивов позиции не могут исчезнуть, поэтому там `undefined` становится `null`:
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+Проверка `obj.key === undefined` не может различить две ситуации: свойство не существует, или оно существует и содержит значение `undefined`.
+`Object.hasOwn(obj, key)` отвечает только на первый вопрос: он возвращает `true`, когда у объекта есть **собственное** свойство с именем `key`, каковым бы ни было его значение:
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+«Собственное» означает объявленное на самом объекте: унаследованные члены, такие как `toString`, доступны у каждого объекта, но `Object.hasOwn(config, "toString")` даёт `false`.

--- a/zh/javascript/data.json
+++ b/zh/javascript/data.json
@@ -93,5 +93,10 @@
         "order": 19,
         "title": "箭头函数",
         "description": "学习如何编写简短的匿名函数"
+    },
+    "nullability": {
+        "order": 20,
+        "title": "可空性",
+        "description": "学习如何处理可能为 null 或 undefined 的值"
     }
 }

--- a/zh/javascript/nullability/1.md
+++ b/zh/javascript/nullability/1.md
@@ -1,0 +1,65 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+JavaScript 有两种不同的方式来表示"这里没有值"。
+`undefined` 表示一个值**从未被提供**。声明时没有赋值的变量持有 `undefined`，对象中不存在的属性也是如此：
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` 是**你**有意赋的一个值，用来表示"它是空的，而且我知道"：
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+所以 `undefined` 通常是语言在告诉你缺少了什么，而 `null` 是程序员在声明某处是有意为空的。
+
+# --instructions--
+
+补全代码，使 `city` 声明时不带值，并将 `owner` 显式设置为 `null`
+
+# --seed--
+
+```javascript
+let [/];
+console.log(city);
+let owner = [/];
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --answers--
+
+- city
+- null
+- undefined
+- nil
+- 0
+- city = 0
+
+# --solutions--
+
+```javascript
+let city;
+console.log(city);
+let owner = null;
+console.log(owner);
+const user = { name: "Ana" };
+console.log(user.age);
+```
+
+# --output--
+
+undefined
+null
+undefined

--- a/zh/javascript/nullability/10.md
+++ b/zh/javascript/nullability/10.md
@@ -1,0 +1,104 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+**默认参数**在调用者不提供值时给参数一个值。规则很精确：只有当实参是 `undefined` 时才使用默认值，这也包括省略实参。传入 `null` **不会**触发默认值，因为 `null` 是一个值：
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+默认参数遵循 `undefined` 规则，而 `??` 同时覆盖 `null` 和 `undefined`：选择与你的函数被调用方式相匹配的那一个。
+
+# --instructions--
+
+编写一个函数 `pad(text, width = 5)`，返回 `text` 后跟足够多的 `"."` 字符以达到 `width` 个字符，为 `width` 使用默认参数；当 `text` 已经达到 `width` 个字符或更长时，原样返回它
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pad() {
+
+}
+```
+
+# --asserts--
+
+`pad("ab", 4)` 必须返回 `"ab.."`。
+
+```javascript
+tryCatch(pad("ab", 4) === "ab..");
+```
+
+`pad("ab")` 必须返回 `"ab..."`，使用默认宽度 `5`。
+
+```javascript
+tryCatch(pad("ab") === "ab...");
+```
+
+`pad("ab", undefined)` 也必须使用默认宽度。
+
+```javascript
+tryCatch(pad("ab", undefined) === "ab...");
+```
+
+`pad("ab", null)` 必须返回 `"ab"`，因为 `null` 不会触发默认值，并且会被转换为 `0`。
+
+```javascript
+tryCatch(pad("ab", null) === "ab");
+```
+
+`pad("abcdef")` 必须原样返回 `"abcdef"`。
+
+```javascript
+tryCatch(pad("abcdef") === "abcdef");
+```
+
+`width` 必须声明为默认参数。
+
+```javascript
+tryCatch(/width\s*=\s*5/.test(pad.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pad(text, width = 5) {
+  return text.padEnd(width, ".");
+}
+```

--- a/zh/javascript/nullability/11.md
+++ b/zh/javascript/nullability/11.md
@@ -1,0 +1,73 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --description--
+
+可选链和 `== null` 守卫配合得很好：链在不抛出错误的情况下读取嵌套值，而守卫决定结果缺失时该做什么：
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+在最后一个 `return` 中，普通的 `.` 是安全的，因为守卫已经证明了每一环都存在。
+
+# --instructions--
+
+对各行排序以定义 `cityOf`，当用户没有城市时返回 `"unknown"`，否则返回城市，然后为没有地址的用户和住在 `Rome` 的用户打印结果。先定义函数
+
+# --answers--
+
+```javascript
+function cityOf(user) {
+```
+
+```javascript
+  if (user?.address?.city == null) {
+```
+
+```javascript
+    return "unknown";
+```
+
+```javascript
+  }
+```
+
+```javascript
+  return user.address.city;
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(cityOf({ name: "Ana" }));
+```
+
+```javascript
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --solutions--
+
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+console.log(cityOf({ name: "Ana" }));
+console.log(cityOf({ address: { city: "Rome" } }));
+```
+
+# --output--
+
+unknown
+Rome

--- a/zh/javascript/nullability/12.md
+++ b/zh/javascript/nullability/12.md
@@ -1,0 +1,97 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+许多内置方法通过返回 `undefined` 来报告"没有找到"。数组方法 `find(callback)` 是典型的例子：它返回第一个使回调为 `true` 的元素，当没有元素匹配时返回 `undefined`：
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+在这里读取 `found.price` 会抛出错误，所以 `?.` 和 `??` 是 `find` 的天然伙伴：
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+# --instructions--
+
+编写一个函数 `priceOf(products, name)`，使用 `find` 返回 `products` 中 `name` 匹配的产品的 `price`，当没有这样的产品时返回 `null`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function priceOf(products, name) {
+
+}
+```
+
+# --asserts--
+
+`priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink")` 必须返回 `7`。
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }, { name: "ink", price: 7 }], "ink") === 7);
+```
+
+`priceOf([{ name: "pen", price: 2 }], "ink")` 必须返回 `null`。
+
+```javascript
+tryCatch(priceOf([{ name: "pen", price: 2 }], "ink") === null);
+```
+
+`priceOf([], "pen")` 必须返回 `null`。
+
+```javascript
+tryCatch(priceOf([], "pen") === null);
+```
+
+`priceOf([{ name: "gift", price: 0 }], "gift")` 必须返回 `0`，而不是 `null`。
+
+```javascript
+tryCatch(priceOf([{ name: "gift", price: 0 }], "gift") === 0);
+```
+
+该函数必须使用 `find`。
+
+```javascript
+tryCatch(/\.find\(/.test(priceOf.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function priceOf(products, name) {
+  return products.find((p) => p.name === name)?.price ?? null;
+}
+```

--- a/zh/javascript/nullability/13.md
+++ b/zh/javascript/nullability/13.md
@@ -1,0 +1,38 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+当对象用 `JSON.stringify()` 转换为 JSON 时，`null` 和 `undefined` 的表现不同。
+JSON 有 `null` 值但没有 `undefined`，所以值为 `undefined` 的属性会被直接**省略**，而 `null` 属性会被保留：
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+在数组内部位置不能消失，所以 `undefined` 在那里会变成 `null`：
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+# --instructions--
+
+这段代码打印什么？
+```javascript
+const item = { id: 7, note: undefined, tags: [undefined], owner: null };
+console.log(JSON.stringify(item));
+```
+
+# --answers--
+
+- {"id":7,"tags":[null],"owner":null}
+- {"id":7,"note":undefined,"tags":[undefined],"owner":null}
+- {"id":7,"tags":[],"owner":null}
+- {"id":7,"tags":[null]}
+
+# --solutions--
+
+- {"id":7,"tags":[null],"owner":null}

--- a/zh/javascript/nullability/14.md
+++ b/zh/javascript/nullability/14.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+检查 `obj.key === undefined` 无法区分两种情况：属性不存在，或者属性存在但持有值 `undefined`。
+`Object.hasOwn(obj, key)` 只回答第一个问题：当对象拥有名为 `key` 的**自有**属性时返回 `true`，无论其值是什么：
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"自有"意味着声明在对象本身上：像 `toString` 这样的继承成员在每个对象上都可用，但 `Object.hasOwn(config, "toString")` 是 `false`。
+
+# --instructions--
+
+编写一个函数 `describeKey(obj, key)`，使用 `Object.hasOwn`：当 `obj` 没有自有属性 `key` 时返回 `"missing"`，当属性存在但持有 `null` 或 `undefined` 时返回 `"empty"`，在其他所有情况下返回 `"set"`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function describeKey(obj, key) {
+
+}
+```
+
+# --asserts--
+
+`describeKey({ a: 1 }, "a")` 必须返回 `"set"`。
+
+```javascript
+tryCatch(describeKey({ a: 1 }, "a") === "set");
+```
+
+`describeKey({ a: 0 }, "a")` 和 `describeKey({ a: "" }, "a")` 必须返回 `"set"`。
+
+```javascript
+tryCatch(describeKey({ a: 0 }, "a") === "set" && describeKey({ a: "" }, "a") === "set");
+```
+
+`describeKey({ a: undefined }, "a")` 和 `describeKey({ a: null }, "a")` 必须返回 `"empty"`。
+
+```javascript
+tryCatch(describeKey({ a: undefined }, "a") === "empty" && describeKey({ a: null }, "a") === "empty");
+```
+
+`describeKey({}, "a")` 必须返回 `"missing"`。
+
+```javascript
+tryCatch(describeKey({}, "a") === "missing");
+```
+
+`describeKey({}, "toString")` 必须返回 `"missing"`，因为 `toString` 是继承的，不是自有的。
+
+```javascript
+tryCatch(describeKey({}, "toString") === "missing");
+```
+
+该函数必须使用 `Object.hasOwn`。
+
+```javascript
+tryCatch(/Object\.hasOwn\(/.test(describeKey.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function describeKey(obj, key) {
+  if (!Object.hasOwn(obj, key)) {
+    return "missing";
+  }
+  if (obj[key] == null) {
+    return "empty";
+  }
+  return "set";
+}
+```

--- a/zh/javascript/nullability/15.md
+++ b/zh/javascript/nullability/15.md
@@ -1,0 +1,51 @@
+---
+language: javascript
+exerciseType: 4
+---
+
+# --instructions--
+
+对各行排序以定义 `finish`，它调用任务的可选 `onDone` 回调并返回其 `name` 或 `"untitled"`，然后为名为 `build` 且带有打印 `done` 的回调的任务、以及一个空任务打印结果。先定义函数
+
+# --answers--
+
+```javascript
+function finish(task) {
+```
+
+```javascript
+  task.onDone?.();
+```
+
+```javascript
+  return task.name ?? "untitled";
+```
+
+```javascript
+}
+```
+
+```javascript
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+```
+
+```javascript
+console.log(finish({}));
+```
+
+# --solutions--
+
+```javascript
+function finish(task) {
+  task.onDone?.();
+  return task.name ?? "untitled";
+}
+console.log(finish({ name: "build", onDone: () => console.log("done") }));
+console.log(finish({}));
+```
+
+# --output--
+
+done
+build
+untitled

--- a/zh/javascript/nullability/16.md
+++ b/zh/javascript/nullability/16.md
@@ -1,0 +1,92 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --instructions--
+
+编写一个函数 `pick(obj, path, fallback)`，其中 `path` 是由点分隔的属性名字符串，例如 `"address.city"`；它必须返回沿路径找到的嵌套值，当任何一步或最终值是 `null` 或 `undefined` 时返回 `fallback`；像 `0`、`""` 和 `false` 这样的值必须原样返回
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function pick(obj, path, fallback) {
+
+}
+```
+
+# --asserts--
+
+`pick({ address: { city: "Rome" } }, "address.city", "unknown")` 必须返回 `"Rome"`。
+
+```javascript
+tryCatch(pick({ address: { city: "Rome" } }, "address.city", "unknown") === "Rome");
+```
+
+`pick({ address: null }, "address.city", "unknown")` 必须返回 `"unknown"`。
+
+```javascript
+tryCatch(pick({ address: null }, "address.city", "unknown") === "unknown");
+```
+
+`pick({}, "a.b.c", 0)` 必须返回 `0` 且不抛出错误。
+
+```javascript
+tryCatch(pick({}, "a.b.c", 0) === 0);
+```
+
+`pick({ count: 0 }, "count", 5)` 必须返回 `0`，且 `pick({ name: "" }, "name", "anon")` 必须返回 `""`。
+
+```javascript
+tryCatch(pick({ count: 0 }, "count", 5) === 0 && pick({ name: "" }, "name", "anon") === "");
+```
+
+`pick({ flags: { on: false } }, "flags.on", true)` 必须返回 `false`。
+
+```javascript
+tryCatch(pick({ flags: { on: false } }, "flags.on", true) === false);
+```
+
+`pick(null, "x", "none")` 和 `pick({ x: undefined }, "x", "none")` 必须返回 `"none"`。
+
+```javascript
+tryCatch(pick(null, "x", "none") === "none" && pick({ x: undefined }, "x", "none") === "none");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function pick(obj, path, fallback) {
+  let current = obj;
+  for (const key of path.split(".")) {
+    current = current?.[key];
+  }
+  return current ?? fallback;
+}
+```

--- a/zh/javascript/nullability/2.md
+++ b/zh/javascript/nullability/2.md
@@ -1,0 +1,107 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+还有两种情况会让函数产生 `undefined`。
+当你调用函数时传入的**实参数量少于**它声明的形参数量，缺失的参数会持有 `undefined`：
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+当函数**没有 `return`** 就结束（或者只有单独的 `return;`）时，调用它会得到 `undefined`：
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+注意，显式传入 `null` 与省略实参并不相同：`greet(null)` 打印 `null`，因为 `null` 是一个真正传递给函数的值。
+
+# --instructions--
+
+编写一个函数 `nameOrGuest(name)`，当 `name` 是 `undefined` 时（例如因为省略了实参）返回 `"Guest"`，在其他所有情况下（包括 `null`）原样返回 `name`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function nameOrGuest(name) {
+
+}
+```
+
+# --asserts--
+
+`nameOrGuest("Ana")` 必须返回 `"Ana"`。
+
+```javascript
+tryCatch(nameOrGuest("Ana") === "Ana");
+```
+
+`nameOrGuest()` 必须返回 `"Guest"`，因为缺失的实参是 `undefined`。
+
+```javascript
+tryCatch(nameOrGuest() === "Guest");
+```
+
+`nameOrGuest(undefined)` 必须返回 `"Guest"`。
+
+```javascript
+tryCatch(nameOrGuest(undefined) === "Guest");
+```
+
+`nameOrGuest(null)` 必须返回 `null`，因为 `null` 是有意传入的值。
+
+```javascript
+tryCatch(nameOrGuest(null) === null);
+```
+
+`nameOrGuest("")` 必须返回 `""`。
+
+```javascript
+tryCatch(nameOrGuest("") === "");
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function nameOrGuest(name) {
+  if (name === undefined) {
+    return "Guest";
+  }
+  return name;
+}
+```

--- a/zh/javascript/nullability/3.md
+++ b/zh/javascript/nullability/3.md
@@ -1,0 +1,37 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+`typeof` 运算符以字符串形式返回值的类型。对于 `undefined`，它如你所愿地回答 `"undefined"`：
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+然而对于 `null`，它回答的是 `"object"`。这是 JavaScript 第一个版本就存在且从未被修复的 bug，因为有太多代码依赖它：
+```javascript
+console.log(typeof null);
+// prints object
+```
+所以 `typeof` 是检测 `undefined` 的可靠方式，但不适用于 `null`。要检查 `null`，直接与它比较即可：`value === null`。
+
+# --instructions--
+
+这段代码打印什么？
+```javascript
+console.log(typeof null, typeof undefined);
+```
+
+# --answers--
+
+- object undefined
+- null undefined
+- undefined undefined
+- object object
+
+# --solutions--
+
+- object undefined

--- a/zh/javascript/nullability/4.md
+++ b/zh/javascript/nullability/4.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+`null` 和 `undefined` 相互比较时结果如何？这取决于运算符。
+**宽松**相等 `==` 把它们视为同一种东西，并认为它们与任何其他值都不同，包括 `0`、`""` 和 `false`：
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**严格**相等 `===` 还会比较类型，而 `null` 和 `undefined` 的类型不同：
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+# --instructions--
+
+补全代码，使第一行用宽松相等比较 `missing` 和 `undefined`，第二行用严格相等，第三行检查 `typeof missing` 的结果，产生输出 `true`、`false`、`true`
+
+# --seed--
+
+```javascript
+let missing = null;
+console.log(missing [/] undefined);
+console.log(missing [/] undefined);
+console.log(typeof missing === [/]);
+```
+
+# --answers--
+
+- ==
+- ===
+- "object"
+- "null"
+- "undefined"
+- =
+- equals
+
+# --solutions--
+
+```javascript
+let missing = null;
+console.log(missing == undefined);
+console.log(missing === undefined);
+console.log(typeof missing === "object");
+```
+
+# --output--
+
+true
+false
+true

--- a/zh/javascript/nullability/5.md
+++ b/zh/javascript/nullability/5.md
@@ -1,0 +1,101 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+大多数时候你并不关心得到的是两个"无值"标记中的*哪一个*：你只想知道值是否存在。
+由于 `null == undefined` 是 `true`，且没有其他值与 `null` 宽松相等，比较 `value == null` 就是一次捕获**两者**的标准惯用法：
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+这是唯一一个 `==` 比 `===` 更受青睐的场景：写 `value === null || value === undefined` 做的事完全一样，只是更长。
+`0`、`""` 和 `false` 这样的值*不是* `null`：它们是恰好为假值的真实值。
+
+# --instructions--
+
+编写一个函数 `isMissing(value)`，当 `value` 是 `null` 或 `undefined` 时返回 `true`，对任何其他值返回 `false`
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function isMissing(value) {
+
+}
+```
+
+# --asserts--
+
+`isMissing(null)` 必须返回 `true`。
+
+```javascript
+tryCatch(isMissing(null) === true);
+```
+
+`isMissing(undefined)` 和 `isMissing()` 必须返回 `true`。
+
+```javascript
+tryCatch(isMissing(undefined) === true && isMissing() === true);
+```
+
+`isMissing(0)` 必须返回 `false`。
+
+```javascript
+tryCatch(isMissing(0) === false);
+```
+
+`isMissing("")` 和 `isMissing(false)` 必须返回 `false`。
+
+```javascript
+tryCatch(isMissing("") === false && isMissing(false) === false);
+```
+
+`isMissing([])` 和 `isMissing({})` 必须返回 `false`。
+
+```javascript
+tryCatch(isMissing([]) === false && isMissing({}) === false);
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function isMissing(value) {
+  return value == null;
+}
+```

--- a/zh/javascript/nullability/6.md
+++ b/zh/javascript/nullability/6.md
@@ -1,0 +1,55 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+读取 `null` 或 `undefined` 的属性是一个会中止程序的错误：
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` 是 `undefined`，而 `undefined` 没有任何属性。**可选链**运算符 `?.` 解决了这个问题：如果它左边的值是 `null` 或 `undefined`，整个表达式会停止求值并得到 `undefined`，而不是抛出错误：
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+当左边确实有值时，`?.` 的行为与普通的 `.` 完全一样。你可以链接多个：只要任何一环缺失，`user.address?.street?.name` 就会返回 `undefined`。
+
+# --instructions--
+
+使用可选链补全代码，使两行都打印 `undefined` 而不是抛出错误
+
+# --seed--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet[/]name);
+console.log(user.address[/]city);
+```
+
+# --answers--
+
+- ?.
+- ?.
+- .
+- ??
+- ?
+- !.
+
+# --solutions--
+
+```javascript
+const user = { name: "Ana", pet: null };
+console.log(user.pet?.name);
+console.log(user.address?.city);
+```
+
+# --output--
+
+undefined
+undefined

--- a/zh/javascript/nullability/7.md
+++ b/zh/javascript/nullability/7.md
@@ -1,0 +1,102 @@
+---
+language: javascript
+exerciseType: 1
+---
+
+# --description--
+
+可选链并不限于点属性。它还有另外两种形式。
+`?.[]` 只在左边有值时才读取一个元素或一个计算出来的键：
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` 只在函数存在时才调用它，这对可选的回调非常方便：
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+在每种形式中，检查都作用于 `?.` **紧前面**的值：即使 `post` 本身是 `null` 或 `undefined`，`post?.tags?.[0]` 也是安全的。
+
+# --instructions--
+
+编写一个函数 `firstTag(post)`，返回 `post.tags` 的第一个元素；当 `post` 缺失、没有 `tags` 或其 `tags` 数组为空时返回 `undefined`，使用可选链而不是 `if` 语句
+
+# --before-seed--
+
+```javascript
+// DO NOT EDIT FROM HERE
+var _testFailedCount = 0;
+var _testCount = 0;
+var assert = require('assert')
+const tryCatch = (...args) => {
+  _testCount++
+  try { assert(...args) }
+  catch (e) {
+    _testFailedCount++
+    console.log(`Test Case '--err-t${_testCount}--' failed`);
+  }
+};
+// DO NOT EDIT UNTIL HERE
+```
+
+# --seed--
+
+```javascript
+function firstTag(post) {
+
+}
+```
+
+# --asserts--
+
+`firstTag({ tags: ["js", "node"] })` 必须返回 `"js"`。
+
+```javascript
+tryCatch(firstTag({ tags: ["js", "node"] }) === "js");
+```
+
+`firstTag({ title: "Hello" })` 必须返回 `undefined`，因为没有 `tags` 属性。
+
+```javascript
+tryCatch(firstTag({ title: "Hello" }) === undefined);
+```
+
+`firstTag({ tags: [] })` 必须返回 `undefined`。
+
+```javascript
+tryCatch(firstTag({ tags: [] }) === undefined);
+```
+
+`firstTag(null)` 和 `firstTag(undefined)` 必须返回 `undefined` 且不抛出错误。
+
+```javascript
+tryCatch(firstTag(null) === undefined && firstTag(undefined) === undefined);
+```
+
+该函数必须使用可选链且不使用 `if`。
+
+```javascript
+tryCatch(/\?\./.test(firstTag.toString()) && !/\bif\b/.test(firstTag.toString()));
+```
+
+# --after-asserts--
+
+```javascript
+// DO NOT EDIT FROM HERE 
+console.log(`Executed ${_testCount} tests, with ${_testFailedCount} failures`);
+// DO NOT EDIT UNTIL HERE
+```
+
+# --solutions--
+
+```javascript
+function firstTag(post) {
+  return post?.tags?.[0];
+}
+```

--- a/zh/javascript/nullability/8.md
+++ b/zh/javascript/nullability/8.md
@@ -1,0 +1,60 @@
+---
+language: javascript
+exerciseType: 2
+---
+
+# --description--
+
+一旦知道一个值可能缺失，你通常希望在它的位置放一个**默认值**。有两个运算符可以做到这一点，它们对什么算"缺失"的判断不同。
+只要 `a` 是**假值**，`a || b` 就返回 `b`：不仅是 `null` 和 `undefined`，还有 `0`、`""`、`false` 和 `NaN`。
+**空值合并**运算符 `a ?? b` 只在 `a` 是 `null` 或 `undefined` 时才返回 `b`，并保留所有其他值：
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+当 `0`、`""` 或 `false` 是必须保留的合法值时使用 `??`，当你确实想替换每一个假值时使用 `||`。
+
+# --instructions--
+
+补全代码，使第一行保留存储在 `count` 中的 `0`，第二行用 `"Guest"` 替换空的 `name`，第三行保留值 `false`
+
+# --seed--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count [/] 10);
+console.log(name [/] "Guest");
+console.log(false [/] true);
+```
+
+# --answers--
+
+- ??
+- ||
+- ??
+- ?
+- or
+- !!
+
+# --solutions--
+
+```javascript
+const count = 0;
+const name = "";
+console.log(count ?? 10);
+console.log(name || "Guest");
+console.log(false ?? true);
+```
+
+# --output--
+
+0
+Guest
+false

--- a/zh/javascript/nullability/9.md
+++ b/zh/javascript/nullability/9.md
@@ -1,0 +1,42 @@
+---
+language: javascript
+exerciseType: 3
+---
+
+# --description--
+
+一个非常常见的模式是"仅当此属性尚未设置时才填入它"。用 `??` 书写会重复属性名：
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**空值赋值**运算符 `??=` 一步完成同样的事：只有当左边当前是 `null` 或 `undefined` 时才赋上右边的值，并保持任何其他值不变：
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` 保持为 `0`，因为 `0` 不是空值；`timeout` 原本不存在，所以它获得 `1000`。同样的想法对 `||` 也存在，即 `||=`，它会覆盖每一个假值。
+
+# --instructions--
+
+这段代码打印什么？
+```javascript
+const options = { retries: 0, timeout: null };
+options.retries ??= 3;
+options.timeout ??= 1000;
+options.name ??= "job";
+console.log(options.retries, options.timeout, options.name);
+```
+
+# --answers--
+
+- 0 1000 job
+- 3 1000 job
+- 0 null job
+- 3 1000 undefined
+
+# --solutions--
+
+- 0 1000 job

--- a/zh/javascript/nullability/_theory.md
+++ b/zh/javascript/nullability/_theory.md
@@ -1,0 +1,233 @@
+JavaScript 有两种不同的方式来表示"这里没有值"。
+`undefined` 表示一个值**从未被提供**。声明时没有赋值的变量持有 `undefined`，对象中不存在的属性也是如此：
+```javascript
+let city;
+console.log(city);
+// prints undefined
+const user = { name: "Ana" };
+console.log(user.age);
+// prints undefined
+```
+`null` 是**你**有意赋的一个值，用来表示"它是空的，而且我知道"：
+```javascript
+let owner = null;
+console.log(owner);
+// prints null
+```
+所以 `undefined` 通常是语言在告诉你缺少了什么，而 `null` 是程序员在声明某处是有意为空的。
+
+---
+
+还有两种情况会让函数产生 `undefined`。
+当你调用函数时传入的**实参数量少于**它声明的形参数量，缺失的参数会持有 `undefined`：
+```javascript
+function greet(name) {
+  console.log(name);
+}
+greet();
+// prints undefined
+```
+当函数**没有 `return`** 就结束（或者只有单独的 `return;`）时，调用它会得到 `undefined`：
+```javascript
+function log(message) {
+  console.log(message);
+}
+const result = log("hi");
+console.log(result);
+// prints hi, then undefined
+```
+注意，显式传入 `null` 与省略实参并不相同：`greet(null)` 打印 `null`，因为 `null` 是一个真正传递给函数的值。
+
+---
+
+`typeof` 运算符以字符串形式返回值的类型。对于 `undefined`，它如你所愿地回答 `"undefined"`：
+```javascript
+let city;
+console.log(typeof city);
+// prints undefined
+```
+然而对于 `null`，它回答的是 `"object"`。这是 JavaScript 第一个版本就存在且从未被修复的 bug，因为有太多代码依赖它：
+```javascript
+console.log(typeof null);
+// prints object
+```
+所以 `typeof` 是检测 `undefined` 的可靠方式，但不适用于 `null`。要检查 `null`，直接与它比较即可：`value === null`。
+
+---
+
+`null` 和 `undefined` 相互比较时结果如何？这取决于运算符。
+**宽松**相等 `==` 把它们视为同一种东西，并认为它们与任何其他值都不同，包括 `0`、`""` 和 `false`：
+```javascript
+console.log(null == undefined);
+// prints true
+console.log(null == 0, undefined == "");
+// prints false false
+```
+**严格**相等 `===` 还会比较类型，而 `null` 和 `undefined` 的类型不同：
+```javascript
+console.log(null === undefined);
+// prints false
+console.log(null === null);
+// prints true
+```
+
+---
+
+大多数时候你并不关心得到的是两个"无值"标记中的*哪一个*：你只想知道值是否存在。
+由于 `null == undefined` 是 `true`，且没有其他值与 `null` 宽松相等，比较 `value == null` 就是一次捕获**两者**的标准惯用法：
+```javascript
+function show(value) {
+  if (value == null) {
+    return "missing";
+  }
+  return "present";
+}
+console.log(show(null), show(undefined));
+// prints missing missing
+console.log(show(0), show(""));
+// prints present present
+```
+这是唯一一个 `==` 比 `===` 更受青睐的场景：写 `value === null || value === undefined` 做的事完全一样，只是更长。
+`0`、`""` 和 `false` 这样的值*不是* `null`：它们是恰好为假值的真实值。
+
+---
+
+读取 `null` 或 `undefined` 的属性是一个会中止程序的错误：
+```javascript
+const user = { name: "Ana" };
+console.log(user.address.city);
+// TypeError: Cannot read properties of undefined (reading 'city')
+```
+`user.address` 是 `undefined`，而 `undefined` 没有任何属性。**可选链**运算符 `?.` 解决了这个问题：如果它左边的值是 `null` 或 `undefined`，整个表达式会停止求值并得到 `undefined`，而不是抛出错误：
+```javascript
+console.log(user.address?.city);
+// prints undefined
+console.log(user.name?.length);
+// prints 3
+```
+当左边确实有值时，`?.` 的行为与普通的 `.` 完全一样。你可以链接多个：只要任何一环缺失，`user.address?.street?.name` 就会返回 `undefined`。
+
+---
+
+可选链并不限于点属性。它还有另外两种形式。
+`?.[]` 只在左边有值时才读取一个元素或一个计算出来的键：
+```javascript
+const post = { tags: ["js", "node"] };
+console.log(post.tags?.[0]);
+// prints js
+const empty = {};
+console.log(empty.tags?.[0]);
+// prints undefined
+```
+`?.()` 只在函数存在时才调用它，这对可选的回调非常方便：
+```javascript
+const task = { name: "build" };
+task.onDone?.();
+// nothing happens, no error
+```
+在每种形式中，检查都作用于 `?.` **紧前面**的值：即使 `post` 本身是 `null` 或 `undefined`，`post?.tags?.[0]` 也是安全的。
+
+---
+
+一旦知道一个值可能缺失，你通常希望在它的位置放一个**默认值**。有两个运算符可以做到这一点，它们对什么算"缺失"的判断不同。
+只要 `a` 是**假值**，`a || b` 就返回 `b`：不仅是 `null` 和 `undefined`，还有 `0`、`""`、`false` 和 `NaN`。
+**空值合并**运算符 `a ?? b` 只在 `a` 是 `null` 或 `undefined` 时才返回 `b`，并保留所有其他值：
+```javascript
+const count = 0;
+console.log(count || 10);
+// prints 10
+console.log(count ?? 10);
+// prints 0
+let name;
+console.log(name ?? "Guest");
+// prints Guest
+```
+当 `0`、`""` 或 `false` 是必须保留的合法值时使用 `??`，当你确实想替换每一个假值时使用 `||`。
+
+---
+
+一个非常常见的模式是"仅当此属性尚未设置时才填入它"。用 `??` 书写会重复属性名：
+```javascript
+options.timeout = options.timeout ?? 1000;
+```
+**空值赋值**运算符 `??=` 一步完成同样的事：只有当左边当前是 `null` 或 `undefined` 时才赋上右边的值，并保持任何其他值不变：
+```javascript
+const options = { retries: 0 };
+options.retries ??= 3;
+options.timeout ??= 1000;
+console.log(options);
+// prints { retries: 0, timeout: 1000 }
+```
+`retries` 保持为 `0`，因为 `0` 不是空值；`timeout` 原本不存在，所以它获得 `1000`。同样的想法对 `||` 也存在，即 `||=`，它会覆盖每一个假值。
+
+---
+
+**默认参数**在调用者不提供值时给参数一个值。规则很精确：只有当实参是 `undefined` 时才使用默认值，这也包括省略实参。传入 `null` **不会**触发默认值，因为 `null` 是一个值：
+```javascript
+function repeat(text, times = 2) {
+  return text.repeat(times);
+}
+console.log(repeat("ab"));
+// prints abab
+console.log(repeat("ab", undefined));
+// prints abab
+console.log(repeat("ab", null));
+// prints an empty string, because null is converted to 0
+```
+默认参数遵循 `undefined` 规则，而 `??` 同时覆盖 `null` 和 `undefined`：选择与你的函数被调用方式相匹配的那一个。
+
+---
+
+可选链和 `== null` 守卫配合得很好：链在不抛出错误的情况下读取嵌套值，而守卫决定结果缺失时该做什么：
+```javascript
+function cityOf(user) {
+  if (user?.address?.city == null) {
+    return "unknown";
+  }
+  return user.address.city;
+}
+```
+在最后一个 `return` 中，普通的 `.` 是安全的，因为守卫已经证明了每一环都存在。
+
+---
+
+许多内置方法通过返回 `undefined` 来报告"没有找到"。数组方法 `find(callback)` 是典型的例子：它返回第一个使回调为 `true` 的元素，当没有元素匹配时返回 `undefined`：
+```javascript
+const products = [{ name: "pen", price: 2 }];
+const found = products.find((p) => p.name === "ink");
+console.log(found);
+// prints undefined
+```
+在这里读取 `found.price` 会抛出错误，所以 `?.` 和 `??` 是 `find` 的天然伙伴：
+```javascript
+console.log(products.find((p) => p.name === "ink")?.price ?? "no price");
+// prints no price
+```
+
+---
+
+当对象用 `JSON.stringify()` 转换为 JSON 时，`null` 和 `undefined` 的表现不同。
+JSON 有 `null` 值但没有 `undefined`，所以值为 `undefined` 的属性会被直接**省略**，而 `null` 属性会被保留：
+```javascript
+const user = { name: "Ana", nickname: undefined, email: null };
+console.log(JSON.stringify(user));
+// prints {"name":"Ana","email":null}
+```
+在数组内部位置不能消失，所以 `undefined` 在那里会变成 `null`：
+```javascript
+console.log(JSON.stringify([1, undefined, 3]));
+// prints [1,null,3]
+```
+
+---
+
+检查 `obj.key === undefined` 无法区分两种情况：属性不存在，或者属性存在但持有值 `undefined`。
+`Object.hasOwn(obj, key)` 只回答第一个问题：当对象拥有名为 `key` 的**自有**属性时返回 `true`，无论其值是什么：
+```javascript
+const config = { debug: undefined };
+console.log(config.debug === undefined, config.level === undefined);
+// prints true true
+console.log(Object.hasOwn(config, "debug"), Object.hasOwn(config, "level"));
+// prints true false
+```
+"自有"意味着声明在对象本身上：像 `toString` 这样的继承成员在每个对象上都可用，但 `Object.hasOwn(config, "toString")` 是 `false`。


### PR DESCRIPTION
## Summary
- Adds 16 JavaScript exercises on nullability (`undefined`, `null`, optional chaining `?.`, nullish coalescing `??`, and safe defaulting patterns), covering all four exercise types: 7 run-code, 4 fill-empty-spaces, 3 choose-answer, 2 sort-items.
- Available across all 12 locales (en, de, es, fr, hi, it, ja, ko, pl, pt, ru, zh), each with 16 exercises and a generated `_theory.md`.
- Adds the `nullability` entry (order 20) to each locale's `javascript/data.json`.
- Regenerates `curriculum.json` and all `_theory.md` files.

## Checks run
- validator: pass
- tester: 7/7 type-1 en exercises PASS (2, 5, 7, 10, 12, 14, 16) against codecompiler-8081 (production toolchain versions)
- check_outputs_docker.sh: 6 run, 0 failed (1, 4, 6, 8, 11, 15)
- check_locales.py: 0 problems across 17 en files x 11 locales; all 12 locales have 16 exercises + `_theory.md`; all 12 `javascript/data.json` contain `nullability`

## Known issues
None.

## Test plan
- [x] Validator passes
- [x] Type-1 exercises verified against production-version codecompiler container
- [x] Output-based exercises verified via check_outputs_docker.sh
- [x] Locale parity verified via check_locales.py